### PR TITLE
chore: complete AVA rename sync and compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AI Coding Agent Instructions
 
-> Universal instructions for AI assistants working on Estela
+> Universal instructions for AI assistants working on AVA
 
 ---
 
@@ -21,7 +21,7 @@ npx tsc --noEmit       # Type check
 
 ## Project Overview
 
-**Estela** is a multi-agent AI coding assistant - a Tauri 2.0 + SolidJS desktop app with a TypeScript core monorepo and a CLI that speaks ACP for editor integration.
+**AVA** is a multi-agent AI coding assistant - a Tauri 2.0 + SolidJS desktop app with a TypeScript core monorepo and a CLI that speaks ACP for editor integration.
 
 | Layer | Technology |
 |-------|------------|
@@ -37,7 +37,7 @@ npx tsc --noEmit       # Type check
 
 ### Project Structure
 ```
-Estela/
+AVA/
 ├── packages/
 │   ├── core/              # Business logic
 │   ├── platform-node/     # Node.js implementations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
-# Estela
+# AVA
 
 > The Obsidian of AI Coding — Desktop AI coding app with a virtual dev team and community plugins
 
 ---
 
-## What Is Estela
+## What Is AVA
 
 A **desktop-first AI coding app** (Tauri + SolidJS) for developers and vibe coders. Not an IDE replacement — an AI companion with:
 
@@ -45,7 +45,7 @@ npm run analyze          # Bundle size analysis
 ### Project Structure
 
 ```
-Estela/
+AVA/
 ├── src/                   # Desktop app (Tauri + SolidJS) ← PRIMARY
 ├── src-tauri/             # Rust backend
 ├── packages/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Estela
+# AVA
 
 > The Obsidian of AI Coding — Desktop AI coding app with a virtual dev team and community plugins
 
@@ -10,8 +10,8 @@ A Tauri 2.0 + SolidJS desktop application for AI-assisted software development. 
 # Prerequisites: Node.js 20+, Rust 1.70+
 
 # Clone and install
-git clone https://github.com/g0dxn4/Estela.git
-cd Estela
+git clone https://github.com/g0dxn4/AVA.git
+cd AVA
 npm install
 
 # Set up environment (optional - can also configure in Settings UI)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ava/cli",
   "version": "0.1.0",
-  "description": "Estela CLI - ACP-compatible AI coding assistant",
+  "description": "AVA CLI - ACP-compatible AI coding assistant",
   "type": "module",
   "bin": {
     "estela": "dist/index.js"

--- a/cli/src/acp/agent.ts
+++ b/cli/src/acp/agent.ts
@@ -1,5 +1,5 @@
 /**
- * Estela ACP Agent
+ * AVA ACP Agent
  *
  * Implements the Agent Client Protocol for integration with
  * Toad, Zed, and other ACP-compatible editors.
@@ -83,8 +83,8 @@ interface AcpModules {
 // Agent Handler
 // ============================================================================
 
-/** Create the Estela agent handler with ACP module integration */
-function createEstelaAgent(connection: AgentSideConnection, modules: AcpModules): Agent {
+/** Create the AVA agent handler with ACP module integration */
+function createAVAAgent(connection: AgentSideConnection, modules: AcpModules): Agent {
   const { sessionStore, errorHandler, modeManager, mcpBridge } = modules
   const runtimes = new Map<string, SessionRuntime>()
 
@@ -122,7 +122,7 @@ function createEstelaAgent(connection: AgentSideConnection, modules: AcpModules)
       if (mcpConfigs?.length) {
         const connected = await mcpBridge.connectServers(mcpConfigs)
         if (connected.length > 0) {
-          console.error(`[Estela] Connected MCP servers: ${connected.join(', ')}`)
+          console.error(`[AVA] Connected MCP servers: ${connected.join(', ')}`)
         }
       }
 
@@ -264,7 +264,7 @@ async function runToolLoop(
 
       if (delta.done && delta.usage) {
         console.error(
-          `[Estela] Tokens: ${delta.usage.inputTokens} in, ${delta.usage.outputTokens} out`
+          `[AVA] Tokens: ${delta.usage.inputTokens} in, ${delta.usage.outputTokens} out`
         )
       }
     }
@@ -398,7 +398,7 @@ async function handlePromptError(
 }
 
 function buildSystemPrompt(cwd: string): string {
-  return `You are Estela, an AI coding assistant. You are helping a developer in their project located at: ${cwd}
+  return `You are AVA, an AI coding assistant. You are helping a developer in their project located at: ${cwd}
 
 You have access to tools for file operations and shell commands. Use them to help the developer.
 
@@ -478,7 +478,7 @@ export async function startAcpAgent(): Promise<void> {
   const stream = ndJsonStream(writable, readable)
 
   const connection = new AgentSideConnection(
-    (conn) => createEstelaAgent(conn, { sessionStore, errorHandler, modeManager, mcpBridge }),
+    (conn) => createAVAAgent(conn, { sessionStore, errorHandler, modeManager, mcpBridge }),
     stream
   )
 

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,5 +1,5 @@
 /**
- * Estela CLI Auth Command
+ * AVA CLI Auth Command
  * Handles OAuth authentication for LLM providers
  */
 
@@ -131,7 +131,7 @@ async function showAuthStatus(): Promise<void> {
  */
 function printHelp(): void {
   console.log(`
-Estela Auth - Manage authentication for LLM providers
+AVA Auth - Manage authentication for LLM providers
 
 USAGE:
   estela auth <command> [provider]

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Estela CLI Entry Point
+ * AVA CLI Entry Point
  *
  * Usage:
  *   estela              - Interactive TUI mode (future)
@@ -52,7 +52,7 @@ async function main() {
   }
 
   // Default: Show help (TUI not implemented yet)
-  console.log('Estela CLI')
+  console.log('AVA CLI')
   console.log('')
   console.log('TUI mode not yet implemented. Use --acp for ACP agent mode.')
   console.log('Run `estela --help` for more information.')
@@ -60,7 +60,7 @@ async function main() {
 
 function printHelp() {
   console.log(`
-Estela CLI - Multi-Agent AI Coding Assistant
+AVA CLI - Multi-Agent AI Coding Assistant
 
 USAGE:
   estela [OPTIONS]
@@ -95,7 +95,7 @@ ENVIRONMENT VARIABLES:
   ESTELA_OPENROUTER_API_KEY   OpenRouter API key
   ESTELA_OPENAI_API_KEY       OpenAI API key (alternative to OAuth)
 
-For more information, visit: https://github.com/g0dxn4/Estela
+For more information, visit: https://github.com/g0dxn4/AVA
 `)
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Estela Documentation
+# AVA Documentation
 
 > The Obsidian of AI Coding
 
@@ -8,7 +8,7 @@
 
 | Doc | What You'll Learn |
 |-----|-------------------|
-| [**Vision**](VISION.md) | What Estela is, who it's for, what makes it special |
+| [**Vision**](VISION.md) | What AVA is, who it's for, what makes it special |
 | [**Roadmap**](ROADMAP.md) | What's built, what's next |
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -130,7 +130,7 @@ This sprint is partially implemented and now tracked as active.
 
 ## Phase 2: Plugin Ecosystem (IN PROGRESS — THE DIFFERENTIATOR)
 
-This is what makes Estela "The Obsidian of AI Coding". Easy to create, discover, install.
+This is what makes AVA "The Obsidian of AI Coding". Easy to create, discover, install.
 
 ### Sprint 2.1: Plugin Format & SDK (Backend foundation mostly done)
 - [x] Define plugin manifest + parsing/validation (`packages/core/src/extensions/manifest.ts`)

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,4 +1,4 @@
-# Estela — Vision
+# AVA — Vision
 
 > The Obsidian of AI Coding
 
@@ -6,7 +6,7 @@
 
 ## The Pitch
 
-Estela is a **desktop AI coding app** for developers and vibe coders. Think Claude Code meets Obsidian — simple to use, open source, multi-provider, with a community plugin ecosystem where anyone can build and share their workflows.
+AVA is a **desktop AI coding app** for developers and vibe coders. Think Claude Code meets Obsidian — simple to use, open source, multi-provider, with a community plugin ecosystem where anyone can build and share their workflows.
 
 It's not an IDE replacement. It's the AI companion that makes your IDE better.
 
@@ -31,7 +31,7 @@ It's not an IDE replacement. It's the AI companion that makes your IDE better.
 
 ---
 
-## What Makes Estela Special
+## What Makes AVA Special
 
 ### 1. The Dev Team
 
@@ -176,7 +176,7 @@ Priority 5: Agent Network           ← Remote agent calls (A2A)
 - [ ] Documentation site
 
 ### Phase 4: Integrations
-- [ ] Editor integration (ACP — use Estela as VS Code backend)
+- [ ] Editor integration (ACP — use AVA as VS Code backend)
 - [ ] Agent network (A2A — connect to remote agents)
 - [ ] Voice input
 - [ ] Vision models (image understanding)
@@ -185,6 +185,6 @@ Priority 5: Agent Network           ← Remote agent calls (A2A)
 
 ## The Name
 
-**Estela** — Spanish for "star trail" or "wake" (the trail a ship leaves).
+**AVA** — Spanish for "star trail" or "wake" (the trail a ship leaves).
 
 Your AI team leaves a trail of completed work behind it.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,15 +1,15 @@
 # Architecture
 
-> Estela system design — desktop-first AI coding app with a virtual dev team
+> AVA system design — desktop-first AI coding app with a virtual dev team
 
 ---
 
 ## Overview
 
-Estela is a monorepo with three layers:
+AVA is a monorepo with three layers:
 
 ```
-Estela/
+AVA/
 ├── src/                    # Desktop app (Tauri + SolidJS) ← PRIMARY
 ├── src-tauri/              # Rust backend for Tauri
 ├── packages/

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -1,6 +1,6 @@
 # Data Flow
 
-> How data moves through Estela
+> How data moves through AVA
 
 ---
 

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -1,6 +1,6 @@
 # Backend — @ava/core
 
-> The brain of Estela. 234 files, ~56,500 lines, 1778 tests across 64 test files.
+> The brain of AVA. 234 files, ~56,500 lines, 1778 tests across 64 test files.
 
 **Package:** `packages/core/` | **Entry:** `packages/core/src/index.ts` | **Exports:** 33 modules
 

--- a/docs/backend/gap-analysis.md
+++ b/docs/backend/gap-analysis.md
@@ -1,6 +1,6 @@
 # Competitive Gap Analysis
 
-> Estela vs 7 reference codebases + PI Coding Agent. Compiled 2026-02-08.
+> AVA vs 7 reference codebases + PI Coding Agent. Compiled 2026-02-08.
 >
 > Sources analyzed: **OpenCode**, **Aider**, **Cline**, **Gemini CLI**, **Goose**, **OpenHands**, **Plandex**, **PI Coding Agent**
 
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-Estela has strong foundations in multi-agent orchestration, codebase intelligence, memory, and permissions — areas where most competitors have nothing. But there are **15 high-impact gaps** that multiple codebases implement and Estela lacks entirely.
+AVA has strong foundations in multi-agent orchestration, codebase intelligence, memory, and permissions — areas where most competitors have nothing. But there are **15 high-impact gaps** that multiple codebases implement and AVA lacks entirely.
 
 **Closed since last update (Sessions 48-53):** message queue, file watcher, step-level undo, git auto-commit, weak/editor model split, streaming tool preview.
 
@@ -58,7 +58,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Plandex**: Version control on plans with rewind/branch. Every plan change creates a versioned snapshot.
 - **Aider**: Git auto-commit = implicit checkpoint. `/undo` reverts last commit.
 
-**Estela status**: Session forking exists ("Fork from here") but it's one-time branching, not iterative checkpointing. `createCheckpoint()` / `rollbackToCheckpoint()` were scaffolded in Session 40 but not wired to UI.
+**AVA status**: Session forking exists ("Fork from here") but it's one-time branching, not iterative checkpointing. `createCheckpoint()` / `rollbackToCheckpoint()` were scaffolded in Session 40 but not wired to UI.
 
 **Impact**: Enables exploratory coding — try approach A, rollback, try approach B. Critical for vibe coders.
 
@@ -76,7 +76,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **PI**: `/session` command shows token count + estimated cost.
 - **Gemini CLI**: Token usage displayed per response.
 
-**Estela status**: Internal `ContextTracker` counts tokens. `ContextBar.tsx` shows a progress bar. No cost calculation, no per-request metrics, no cache tracking.
+**AVA status**: Internal `ContextTracker` counts tokens. `ContextBar.tsx` shows a progress bar. No cost calculation, no per-request metrics, no cache tracking.
 
 **Impact**: Users managing API budgets need cost visibility. #1 requested feature in most AI coding tools.
 
@@ -93,7 +93,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Aider**: `/add image.png`, `/paste` from clipboard, auto-detects vision models.
 - **PI**: Image input support in chat.
 
-**Estela status**: Browser tool takes screenshots but images can't be input to chat. No vision model detection.
+**AVA status**: Browser tool takes screenshots but images can't be input to chat. No vision model detection.
 
 **Impact**: Visual debugging (screenshot → fix), mockup → code, diagram → implementation.
 
@@ -109,7 +109,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Aider**: Auto-commit after every edit. Weak model generates commit message. `/undo` reverts last. Author attribution: `"User (aider)"`.
 - **Gemini CLI**: Git checkpoint integration for time-travel.
 
-**Estela status**: **DONE**. `git/auto-commit.ts` auto-stages and commits after file-modifying tools. Settings UI toggle in Behavior tab. `undoLastAutoCommit()` reverts the most recent estela commit. Commit message prefix is configurable.
+**AVA status**: **DONE**. `git/auto-commit.ts` auto-stages and commits after file-modifying tools. Settings UI toggle in Behavior tab. `undoLastAutoCommit()` reverts the most recent estela commit. Commit message prefix is configurable.
 
 **Impact**: Safety net. Never lose work. Git history shows exactly what AI changed vs what user changed.
 
@@ -123,7 +123,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Aider**: `weak_model_name` per model. Claude Sonnet → Claude Haiku for commits.
 - **PI**: Different models for different sub-tasks.
 
-**Estela status**: **DONE**. `weakModel` optional field in `ProviderSettings` + `getWeakModelConfig()` helper. Planner and self-review validator use weak model when configured. Frontend: dropdown in LLM tab with model pair auto-suggestions. Off by default (uses primary model).
+**AVA status**: **DONE**. `weakModel` optional field in `ProviderSettings` + `getWeakModelConfig()` helper. Planner and self-review validator use weak model when configured. Frontend: dropdown in LLM tab with model pair auto-suggestions. Off by default (uses primary model).
 
 **Impact**: 50-80% cost reduction on secondary tasks (commit messages, summaries, simple classification).
 
@@ -138,7 +138,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **OpenHands**: Full containerized sandbox — every agent runs in Docker with mounted workspace.
 - **Goose**: Extension-based sandboxing.
 
-**Estela status**: No sandboxing. Bash tool executes directly on host. Permission system is the safety layer.
+**AVA status**: No sandboxing. Bash tool executes directly on host. Permission system is the safety layer.
 
 **Impact**: Safety for autonomous agents. Critical for "let it run overnight" workflows.
 
@@ -155,7 +155,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Cline**: Editor integration with VS Code Problems panel.
 - **Gemini CLI**: Auto-test + auto-lint with feedback loop.
 
-**Estela status**: `validator/` module has linting checks (syntax, TypeScript, eslint) but it's **read-only** — doesn't feed errors back to the model for retry.
+**AVA status**: `validator/` module has linting checks (syntax, TypeScript, eslint) but it's **read-only** — doesn't feed errors back to the model for retry.
 
 **Impact**: Dramatically improves first-time code correctness. Agent fixes its own mistakes.
 
@@ -171,7 +171,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Cline**: `handlePartialBlock()` in tool handlers. See diffs appearing in real-time.
 - **OpenCode**: Streaming tool execution with live terminal output.
 
-**Estela status**: **DONE** — Already implemented in the streaming pipeline. `onToolUpdate` callback fires on every tool state change during streaming, updating `session.updateMessage()` reactively. `ToolCallGroup` auto-expands while active (pending/running tools). `ToolCallCard` shows spinner for running tools, status transitions, args summary, duration, and expandable output. The full reactive chain: `streamResponse` → `onToolUpdate` → `setActiveToolCalls` + `session.updateMessage` → `MessageBubble` → `ToolCallGroup(isStreaming=true)` → `ToolCallCard`.
+**AVA status**: **DONE** — Already implemented in the streaming pipeline. `onToolUpdate` callback fires on every tool state change during streaming, updating `session.updateMessage()` reactively. `ToolCallGroup` auto-expands while active (pending/running tools). `ToolCallCard` shows spinner for running tools, status transitions, args summary, duration, and expandable output. The full reactive chain: `streamResponse` → `onToolUpdate` → `setActiveToolCalls` + `session.updateMessage` → `MessageBubble` → `ToolCallGroup(isStreaming=true)` → `ToolCallCard`.
 
 **Impact**: Better perceived performance. User sees progress immediately.
 
@@ -185,9 +185,9 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Aider**: `watch.py` — `AI!` triggers edit, `AI?` triggers question. Works with any language.
 - **OpenCode**: File watcher for reactive workflows.
 
-**Estela status**: **DONE** — `src/services/file-watcher.ts` watches project directory via Tauri FS plugin. Detects `// AI!`, `// AI?`, `# AI!`, `# AI?`, `-- AI!`, `-- AI?` patterns across 30+ file extensions. 500ms debounced recursive watch. Configurable toggle in Settings → Behavior. Wired to ChatView — detected comments auto-send as chat messages.
+**AVA status**: **DONE** — `src/services/file-watcher.ts` watches project directory via Tauri FS plugin. Detects `// AI!`, `// AI?`, `# AI!`, `# AI?`, `-- AI!`, `-- AI?` patterns across 30+ file extensions. 500ms debounced recursive watch. Configurable toggle in Settings → Behavior. Wired to ChatView — detected comments auto-send as chat messages.
 
-**Impact**: Seamless IDE integration without VS Code extension. User writes comment, switches to Estela, sees result.
+**Impact**: Seamless IDE integration without VS Code extension. User writes comment, switches to AVA, sees result.
 
 ---
 
@@ -199,7 +199,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Aider**: `architect_coder.py`. o1 (architect) + Sonnet (editor). `editor-diff` format.
 - **PI**: Extensible model routing for different task phases.
 
-**Estela status**: **DONE**. `editorModel` optional field in `ProviderSettings` + `getEditorModelConfig()` helper. Commander executor auto-applies editor model to workers (Junior Devs) when no per-worker override exists. Frontend: dropdown in LLM tab with 8 editor model presets and auto-pair suggestions (e.g., Opus → Sonnet, Sonnet → Haiku). Team Lead uses primary (architect) model for planning, Junior Devs use cheaper editor model for file changes.
+**AVA status**: **DONE**. `editorModel` optional field in `ProviderSettings` + `getEditorModelConfig()` helper. Commander executor auto-applies editor model to workers (Junior Devs) when no per-worker override exists. Frontend: dropdown in LLM tab with 8 editor model presets and auto-pair suggestions (e.g., Opus → Sonnet, Sonnet → Haiku). Team Lead uses primary (architect) model for planning, Junior Devs use cheaper editor model for file changes.
 
 **Impact**: Better results with reasoning models (o1, DeepSeek R1) that plan well but edit poorly. Cost savings.
 
@@ -214,7 +214,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Cline**: Checkpoint restore (task, workspace, or both).
 - **Plandex**: Plan rewind/branch with version control.
 
-**Estela status**: **DONE** — Built on git auto-commit foundation. Each file-modifying tool creates an estela-prefixed commit. Undo button in MessageInput toolbar reverts the most recent estela commit via `git revert --no-edit`. Shows success/error feedback for 2.5s. Only visible when git auto-commit is enabled. Plus session checkpoints (from Session 40) for coarser rollback.
+**AVA status**: **DONE** — Built on git auto-commit foundation. Each file-modifying tool creates an estela-prefixed commit. Undo button in MessageInput toolbar reverts the most recent estela commit via `git revert --no-edit`. Shows success/error feedback for 2.5s. Only visible when git auto-commit is enabled. Plus session checkpoints (from Session 40) for coarser rollback.
 
 **Impact**: Lighter than forking — just undo last step without creating new session.
 
@@ -227,7 +227,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 **Who has it**:
 - **PI**: Message queue with steering (interrupt) and follow-up (after completion) modes.
 
-**Estela status**: **DONE**. `useChat` has a `messageQueue` signal — messages sent while streaming are queued as follow-ups and auto-dequeued after completion. `steer()` function cancels current stream and sends immediately. `Ctrl+Shift+Enter` keyboard shortcut for steering. Queue badge in MessageInput toolbar. Textarea stays enabled during chat streaming for type-ahead. Session switch clears queue. Cancel clears queue.
+**AVA status**: **DONE**. `useChat` has a `messageQueue` signal — messages sent while streaming are queued as follow-ups and auto-dequeued after completion. `steer()` function cancels current stream and sends immediately. `Ctrl+Shift+Enter` keyboard shortcut for steering. Queue badge in MessageInput toolbar. Textarea stays enabled during chat streaming for type-ahead. Session switch clears queue. Cancel clears queue.
 
 **Impact**: Better for long-running tasks. User can steer without canceling.
 
@@ -240,7 +240,7 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 **Who has it**:
 - **Aider**: `repomap.py` with tree-sitter. 100+ language support. Disk-based tag cache.
 
-**Estela status**: `codebase/` module uses LSP-based symbols (5 languages: TS, Python, Go, Rust, Java).
+**AVA status**: `codebase/` module uses LSP-based symbols (5 languages: TS, Python, Go, Rust, Java).
 
 **Impact**: Support any language without installing language servers. Faster than LSP for simple symbol extraction.
 
@@ -256,9 +256,9 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **PI**: `createAgentSession()` SDK + `--mode rpc` for stdin/stdout protocol.
 - **Aider**: Python library mode.
 
-**Estela status**: Planned for Phase 4. Core is importable as library but no RPC server.
+**AVA status**: Planned for Phase 4. Core is importable as library but no RPC server.
 
-**Impact**: Enables embedding Estela in CI/CD, custom tools, other apps.
+**Impact**: Enables embedding AVA in CI/CD, custom tools, other apps.
 
 ---
 
@@ -270,17 +270,17 @@ Estela has strong foundations in multi-agent orchestration, codebase intelligenc
 - **Cline**: PostHog + OpenTelemetry.
 - **Gemini CLI**: Enterprise-grade telemetry.
 
-**Estela status**: None. Privacy-first philosophy.
+**AVA status**: None. Privacy-first philosophy.
 
 **Impact**: Product improvement data. Optional/opt-in is fine.
 
 ---
 
-## What Estela Has That Others Don't
+## What AVA Has That Others Don't
 
-These are Estela's **unique advantages** — features no other codebase implements:
+These are AVA's **unique advantages** — features no other codebase implements:
 
-| Feature | Estela | Closest Competitor |
+| Feature | AVA | Closest Competitor |
 |---------|--------|-------------------|
 | **Multi-agent hierarchy** (Team Lead → Seniors → Juniors) | Built-in with visible UI | None (all are single-agent) |
 | **Worker scope filtering** (each agent only sees relevant files/tools) | Native | None |

--- a/docs/development/completed/25-acp-a2a-protocols.md
+++ b/docs/development/completed/25-acp-a2a-protocols.md
@@ -1,6 +1,6 @@
 # Epic 25: ACP & A2A Protocol Support
 
-> Make Estela work in any editor (ACP) and communicate with other agents (A2A)
+> Make AVA work in any editor (ACP) and communicate with other agents (A2A)
 
 **Research:** [`docs/analysis/gemini-cli/A2A-ACP-RESEARCH.md`](../../analysis/gemini-cli/A2A-ACP-RESEARCH.md)
 
@@ -8,14 +8,14 @@
 
 ## Overview
 
-Two protocols that make Estela interoperable:
+Two protocols that make AVA interoperable:
 
-1. **ACP (Agent Client Protocol)** - Estela works inside Zed, JetBrains, Neovim, etc.
-2. **A2A (Agent-to-Agent Protocol)** - Estela talks to other AI agents over HTTP
+1. **ACP (Agent Client Protocol)** - AVA works inside Zed, JetBrains, Neovim, etc.
+2. **A2A (Agent-to-Agent Protocol)** - AVA talks to other AI agents over HTTP
 
 ```
 ┌──────────┐  ACP   ┌──────────┐  A2A   ┌──────────────┐
-│  Editor   │◄─────►│  Estela  │◄─────►│ Remote Agent  │
+│  Editor   │◄─────►│  AVA  │◄─────►│ Remote Agent  │
 │(Zed/IDEA) │ stdio  │  Agent   │ HTTP   │(GPT/Gemini/..)│
 └──────────┘        └────┬─────┘        └──────────────┘
                          │ MCP
@@ -28,7 +28,7 @@ Two protocols that make Estela interoperable:
 
 ## Sprint 1: ACP Agent (Editor Integration)
 
-**Goal:** Estela runs inside any ACP-compatible editor
+**Goal:** AVA runs inside any ACP-compatible editor
 
 **Estimated scope:** ~1,200 lines
 
@@ -83,7 +83,7 @@ export class AcpAgent {
   async handleInitialize(params: InitializeRequest): Promise<InitializeResponse> {
     return {
       protocolVersion: 1,
-      agentName: 'Estela',
+      agentName: 'AVA',
       agentVersion: '1.0.0',
       capabilities: {
         streaming: true,
@@ -111,7 +111,7 @@ export class AcpAgent {
 
 **File:** `packages/core/src/acp/session.ts`
 
-Bridge between ACP protocol and Estela's AgentExecutor:
+Bridge between ACP protocol and AVA's AgentExecutor:
 
 ```typescript
 export class AcpSession {
@@ -262,7 +262,7 @@ Support `session/set_mode` for agent/plan mode switching from editor UI.
 
 **File:** `packages/core/src/acp/mcp-bridge.ts`
 
-Allow editor to pass MCP server configs to Estela sessions:
+Allow editor to pass MCP server configs to AVA sessions:
 
 ```typescript
 // Editor sends MCP configs in session/new
@@ -290,9 +290,9 @@ Allow editor to pass MCP server configs to Estela sessions:
 
 ---
 
-## Sprint 3: A2A Server (Expose Estela as Agent)
+## Sprint 3: A2A Server (Expose AVA as Agent)
 
-**Goal:** Other agents can connect to Estela over HTTP
+**Goal:** Other agents can connect to AVA over HTTP
 
 **Estimated scope:** ~1,500 lines
 
@@ -301,9 +301,9 @@ Allow editor to pass MCP server configs to Estela sessions:
 **File:** `packages/core/src/a2a/agent-card.ts`
 
 ```typescript
-export function createAgentCard(config: EstelaConfig): AgentCard {
+export function createAgentCard(config: AVAConfig): AgentCard {
   return {
-    name: 'Estela',
+    name: 'AVA',
     description: 'Multi-agent AI coding assistant with browser automation, fuzzy edits, and parallel execution',
     url: `http://localhost:${config.a2aPort}/`,
     protocolVersion: '0.3.0',
@@ -352,7 +352,7 @@ export class A2AServer {
   private app: express.Application;
   private executor: A2AExecutor;
 
-  constructor(config: EstelaConfig) {
+  constructor(config: AVAConfig) {
     this.app = express();
     this.setupRoutes();
   }
@@ -381,7 +381,7 @@ export class A2AServer {
 
 **File:** `packages/core/src/a2a/executor.ts`
 
-Bridge between A2A protocol and Estela's AgentExecutor:
+Bridge between A2A protocol and AVA's AgentExecutor:
 
 ```typescript
 export class A2AExecutor {
@@ -483,7 +483,7 @@ Bearer token authentication for A2A endpoints.
 
 ## Sprint 4: A2A Client (Connect to Remote Agents)
 
-**Goal:** Estela can delegate tasks to other AI agents
+**Goal:** AVA can delegate tasks to other AI agents
 
 **Estimated scope:** ~800 lines
 
@@ -525,7 +525,7 @@ export class A2AClientManager {
 
 **File:** `packages/core/src/tools/remote-agent.ts`
 
-Wrap remote A2A agents as Estela tools:
+Wrap remote A2A agents as AVA tools:
 
 ```typescript
 export const remoteAgentTool = defineTool({
@@ -558,7 +558,7 @@ export class A2AAgentRegistry {
   async register(name: string, url: string): Promise<AgentCard>;
 
   /** Discover agents from config */
-  async discoverFromConfig(config: EstelaConfig): Promise<void>;
+  async discoverFromConfig(config: AVAConfig): Promise<void>;
 
   /** List registered agents */
   list(): RegisteredAgent[];
@@ -628,7 +628,7 @@ Update settings panel to show ACP/A2A configuration.
 ### Sprint 5 Acceptance Criteria
 
 - [ ] ACP/A2A settings configurable
-- [ ] End-to-end test: Editor → Estela (ACP) → Remote Agent (A2A)
+- [ ] End-to-end test: Editor → AVA (ACP) → Remote Agent (A2A)
 - [ ] Documentation updated
 - [ ] Memory bank updated
 

--- a/docs/development/completed/SPRINT_PLAN.md
+++ b/docs/development/completed/SPRINT_PLAN.md
@@ -1,6 +1,6 @@
-# Sprint Plan: Estela Feature Parity
+# Sprint Plan: AVA Feature Parity
 
-> Making Estela as good as Cline and beyond
+> Making AVA as good as Cline and beyond
 
 ---
 

--- a/docs/development/completed/epic-13-config.md
+++ b/docs/development/completed/epic-13-config.md
@@ -6,7 +6,7 @@
 
 ## Goal
 
-Build a comprehensive settings UI for configuring Estela's behavior, providers, and preferences.
+Build a comprehensive settings UI for configuring AVA's behavior, providers, and preferences.
 
 ---
 

--- a/docs/development/completed/epic-15-comparison.md
+++ b/docs/development/completed/epic-15-comparison.md
@@ -1,6 +1,6 @@
 # Epic 15: In-Depth Codebase Comparison
 
-> Estela vs. SOTA AI Coding Agents - Technical Deep Dive
+> AVA vs. SOTA AI Coding Agents - Technical Deep Dive
 
 ---
 
@@ -8,7 +8,7 @@
 
 | Project | Language | LOC (Core) | Stars | Architecture |
 |---------|----------|------------|-------|--------------|
-| **Estela** | TypeScript | ~23,000 | - | Monorepo, Platform-agnostic |
+| **AVA** | TypeScript | ~23,000 | - | Monorepo, Platform-agnostic |
 | **OpenCode** | TypeScript | ~10,000 | 70k+ | Bun-native, Plugin-based |
 | **Aider** | Python | ~35,000 | 25k+ | Monolithic, Git-native |
 | **Goose** | Rust | ~15,000 | 15k+ | Crate-based, MCP-first |
@@ -20,7 +20,7 @@
 
 ### 1.1 Agent Loop Implementation
 
-#### Estela (~2,900 LOC)
+#### AVA (~2,900 LOC)
 ```
 packages/core/src/agent/
 ├── loop.ts          (450 LOC)  - Main executor
@@ -33,7 +33,7 @@ packages/core/src/agent/
 
 **Key Pattern: Event-driven with recovery**
 ```typescript
-// Estela uses enum-based termination tracking
+// AVA uses enum-based termination tracking
 enum AgentTerminateMode {
   ERROR, TIMEOUT, GOAL, MAX_TURNS, ABORTED, NO_COMPLETE_TASK
 }
@@ -129,7 +129,7 @@ if (hookState.hasFiredBeforeAgent) return undefined;
 
 ### Comparison Table: Agent Loop
 
-| Feature | Estela | OpenCode | Aider | Goose | Gemini CLI |
+| Feature | AVA | OpenCode | Aider | Goose | Gemini CLI |
 |---------|--------|----------|-------|-------|------------|
 | Max turns configurable | ✅ 20 | ✅ 100 | ✅ var | ✅ var | ✅ 100 |
 | Doom loop detection | ❌ | ✅ 3x | ❌ | ❌ | ❌ |
@@ -143,7 +143,7 @@ if (hookState.hasFiredBeforeAgent) return undefined;
 
 ### 1.2 Tool System
 
-#### Estela (~2,876 LOC)
+#### AVA (~2,876 LOC)
 ```
 packages/core/src/tools/
 ├── bash.ts          (490 LOC)  - Shell with PTY
@@ -296,7 +296,7 @@ interface ToolInvocation<TParams, TResult> {
 
 ### Comparison Table: Tools
 
-| Feature | Estela | OpenCode | Aider | Goose | Gemini CLI |
+| Feature | AVA | OpenCode | Aider | Goose | Gemini CLI |
 |---------|--------|----------|-------|-------|------------|
 | Total tool LOC | 2,876 | 2,400 | 20,000 | 3,600 | 26,600 |
 | Edit formats | 1 | 1 | 15+ | 1 | 1 |
@@ -312,7 +312,7 @@ interface ToolInvocation<TParams, TResult> {
 
 ### 1.3 Permission System
 
-#### Estela (~784 LOC)
+#### AVA (~784 LOC)
 ```
 packages/core/src/permissions/
 ├── manager.ts       (400 LOC)  - Risk assessment
@@ -415,7 +415,7 @@ protected getMessageBusDecision(signal: AbortSignal): Promise<'ALLOW' | 'DENY' |
 
 ### Comparison Table: Permissions
 
-| Feature | Estela | OpenCode | Aider | Goose | Gemini CLI |
+| Feature | AVA | OpenCode | Aider | Goose | Gemini CLI |
 |---------|--------|----------|-------|-------|------------|
 | Permission LOC | 784 | 500 | 0 | 637 | 1,000+ |
 | Risk classification | ✅ | ❌ | ❌ | ❌ | ✅ Kind |
@@ -429,7 +429,7 @@ protected getMessageBusDecision(signal: AbortSignal): Promise<'ALLOW' | 'DENY' |
 
 ### 1.4 Codebase Understanding
 
-#### Estela (~2,835 LOC)
+#### AVA (~2,835 LOC)
 ```
 packages/core/src/codebase/
 ├── indexer.ts       (350 LOC)  - File discovery
@@ -509,7 +509,7 @@ def get_ranked_tags(self, chat_fnames, other_fnames, max_map_tokens):
 
 ### Comparison Table: Codebase Understanding
 
-| Feature | Estela | OpenCode | Aider | Goose | Gemini CLI |
+| Feature | AVA | OpenCode | Aider | Goose | Gemini CLI |
 |---------|--------|----------|-------|-------|------------|
 | Understanding LOC | 2,835 | 1,000 | 848 | 0 | 0 |
 | File indexing | ✅ | ✅ | ✅ | ❌ | ❌ |
@@ -525,7 +525,7 @@ def get_ranked_tags(self, chat_fnames, other_fnames, max_map_tokens):
 
 ### 1.5 Memory System
 
-#### Estela (~2,747 LOC)
+#### AVA (~2,747 LOC)
 ```
 packages/core/src/memory/
 ├── manager.ts       (300 LOC)  - Unified interface
@@ -592,7 +592,7 @@ pub struct ExtensionData {
 
 ### Comparison Table: Memory
 
-| Feature | Estela | OpenCode | Aider | Goose | Gemini CLI |
+| Feature | AVA | OpenCode | Aider | Goose | Gemini CLI |
 |---------|--------|----------|-------|-------|------------|
 | Memory LOC | 2,747 | 0 | 0 | 191 | 0 |
 | Episodic memory | ✅ | ❌ | ❌ | ❌ | ❌ |
@@ -607,7 +607,7 @@ pub struct ExtensionData {
 
 ### 1.6 Parallel Execution / Multi-Agent
 
-#### Estela (~2,550 LOC)
+#### AVA (~2,550 LOC)
 ```
 packages/core/src/commander/
 ├── executor.ts      (250 LOC)  - Worker execution
@@ -688,7 +688,7 @@ pub enum SessionType {
 
 ### Comparison Table: Parallel Execution
 
-| Feature | Estela | OpenCode | Aider | Goose | Gemini CLI |
+| Feature | AVA | OpenCode | Aider | Goose | Gemini CLI |
 |---------|--------|----------|-------|-------|------------|
 | Parallel LOC | 2,550 | 175 | 0 | 988 | 0 |
 | DAG scheduling | ✅ | ❌ | ❌ | ❌ | ❌ |
@@ -704,7 +704,7 @@ pub enum SessionType {
 
 ### Process Group Handling
 
-#### Estela
+#### AVA
 ```typescript
 // packages/core/src/tools/bash.ts
 // Uses platform abstraction for process groups
@@ -757,7 +757,7 @@ if (isWindows) {
 
 ### Comparison: Shell Execution Features
 
-| Feature | Estela | OpenCode | Aider | Goose | Gemini CLI |
+| Feature | AVA | OpenCode | Aider | Goose | Gemini CLI |
 |---------|--------|----------|-------|-------|------------|
 | Process groups | ✅ | ❌ | ❌ | ✅ | ✅ |
 | PTY support | ✅ | ❌ | ❌ | ❌ | ❌ |
@@ -775,7 +775,7 @@ if (isWindows) {
 
 | Project | Provider LOC | Providers Supported |
 |---------|--------------|---------------------|
-| Estela | ~500 | 7 (Anthropic, OpenAI, OpenRouter, Google, GLM, Kimi, Copilot) |
+| AVA | ~500 | 7 (Anthropic, OpenAI, OpenRouter, Google, GLM, Kimi, Copilot) |
 | OpenCode | ~2,000 | 20+ (via AI SDK) |
 | Aider | ~1,300 | 10+ (via litellm) |
 | Goose | ~15,000 | 30+ (native implementations) |
@@ -783,7 +783,7 @@ if (isWindows) {
 
 ### Key Patterns
 
-#### Estela
+#### AVA
 ```typescript
 // Factory pattern with provider registration
 export async function createClient(provider: LLMProvider): Promise<LLMClient> {
@@ -859,7 +859,7 @@ pub trait Provider: Send + Sync {
 
 | Project | Config LOC | Key Features |
 |---------|------------|--------------|
-| Estela | 2,082 | Zod validation, reactive updates, credential store |
+| AVA | 2,082 | Zod validation, reactive updates, credential store |
 | OpenCode | ~1,500 | YAML config, feature flags, env vars |
 | Aider | ~945 | CLI args, .aider files, model settings |
 | Goose | 2,977 | YAML, migration, extension config |
@@ -867,7 +867,7 @@ pub trait Provider: Send + Sync {
 
 ### Validation Patterns
 
-#### Estela (Zod)
+#### AVA (Zod)
 ```typescript
 export const SettingsSchema = z.object({
   provider: ProviderSettingsSchema,
@@ -910,7 +910,7 @@ pub struct PermissionConfig {
 
 | Project | Test LOC | Test/Impl Ratio | CI/CD |
 |---------|----------|-----------------|-------|
-| Estela | ~2,000 | ~10% | GitHub Actions |
+| AVA | ~2,000 | ~10% | GitHub Actions |
 | OpenCode | ~20,000 | ~200% | GitHub Actions |
 | Aider | ~15,000 | ~50% | GitHub Actions |
 | Goose | ~5,000 | ~30% | GitHub Actions |
@@ -920,7 +920,7 @@ pub struct PermissionConfig {
 
 ## 6. Unique Strengths by Project
 
-### Estela
+### AVA
 1. **Cognitive memory system** - Only agent with episodic/semantic/procedural memory
 2. **DAG-based parallel execution** - Conflict detection & scheduling
 3. **Workers-as-tools pattern** - Hierarchical delegation
@@ -957,7 +957,7 @@ pub struct PermissionConfig {
 
 ---
 
-## 7. What Estela Should Adopt
+## 7. What AVA Should Adopt
 
 ### From OpenCode
 - [ ] Doom loop detection (3x identical tool calls)
@@ -983,7 +983,7 @@ pub struct PermissionConfig {
 
 ## 8. Architecture Diagrams
 
-### Estela Architecture
+### AVA Architecture
 ```
 ┌────────────────────────────────────────────────────────────┐
 │                     LLM Providers (7)                      │
@@ -1055,9 +1055,9 @@ pub struct PermissionConfig {
 
 ## 9. Conclusion
 
-Estela achieves **comprehensive feature parity** with SOTA agents while introducing unique capabilities:
+AVA achieves **comprehensive feature parity** with SOTA agents while introducing unique capabilities:
 
-| Category | Estela Rank | Key Differentiator |
+| Category | AVA Rank | Key Differentiator |
 |----------|-------------|-------------------|
 | Agent Loop | 2nd | Planning + recovery (OpenCode has doom loop) |
 | Tools | 3rd | File locking (Aider has 15+ formats) |
@@ -1069,4 +1069,4 @@ Estela achieves **comprehensive feature parity** with SOTA agents while introduc
 
 **Total Implementation: ~23,000 LOC** (competitive with OpenCode at ~10K, smaller than Aider at ~35K)
 
-The comparison reveals that while each agent excels in specific areas, Estela's unique combination of memory system, parallel execution, and comprehensive validation pipeline positions it as a next-generation AI coding assistant.
+The comparison reveals that while each agent excels in specific areas, AVA's unique combination of memory system, parallel execution, and comprehensive validation pipeline positions it as a next-generation AI coding assistant.

--- a/docs/development/completed/epic-19-tool-hooks-mvp.md
+++ b/docs/development/completed/epic-19-tool-hooks-mvp.md
@@ -34,7 +34,7 @@ Remaining gaps:
 
 ### Tool System Gaps
 
-| Feature | Cline | Estela | Priority |
+| Feature | Cline | AVA | Priority |
 |---------|-------|--------|----------|
 | Tool hooks (PreToolUse, PostToolUse) | ✅ | ✅ | High |
 | `requires_approval` self-report | ✅ | ✅ | High |
@@ -46,7 +46,7 @@ Remaining gaps:
 
 ### System Prompt Gaps
 
-| Feature | Cline | Estela | Priority |
+| Feature | Cline | AVA | Priority |
 |---------|-------|--------|----------|
 | RULES section with detailed guidance | ✅ 10k | ✅ | High |
 | CAPABILITIES section | ✅ | ✅ | Medium |

--- a/docs/development/completed/epic-26-gemini-cli-features.md
+++ b/docs/development/completed/epic-26-gemini-cli-features.md
@@ -1,6 +1,6 @@
 # Epic 26: Gemini CLI Feature Parity
 
-> Infrastructure features from Gemini CLI that enhance Estela's safety, extensibility, and UX
+> Infrastructure features from Gemini CLI that enhance AVA's safety, extensibility, and UX
 
 **Analysis:** [`docs/analysis/gemini-cli/COMPARISON.md`](../../analysis/gemini-cli/COMPARISON.md)
 

--- a/docs/development/completed/epic-6-dx.md
+++ b/docs/development/completed/epic-6-dx.md
@@ -6,7 +6,7 @@
 
 ## Goal
 
-Improve the developer experience for both Estela contributors and users. Better tool definitions with validation, unified diff tracking, and git-based safety snapshots.
+Improve the developer experience for both AVA contributors and users. Better tool definitions with validation, unified diff tracking, and git-based safety snapshots.
 
 ---
 

--- a/docs/development/completed/epic-7-platform.md
+++ b/docs/development/completed/epic-7-platform.md
@@ -333,7 +333,7 @@ export async function discoverServers(): Promise<MCPServer[]> {
     }
   } catch {}
 
-  // Check Estela config
+  // Check AVA config
   const estelaConfig = join(homedir(), '.estela', 'mcp.json')
   try {
     const config = JSON.parse(await readFile(estelaConfig, 'utf-8'))
@@ -414,6 +414,6 @@ This epic owns:
 - [ ] PTY works for interactive commands (ssh, vim)
 - [ ] PTY falls back to regular shell when not supported
 - [ ] MCP client connects to stdio and SSE servers
-- [ ] MCP server discovery finds Claude Code and Estela configs
+- [ ] MCP server discovery finds Claude Code and AVA configs
 - [ ] MCP tools appear in LLM tool list with `mcp_` prefix
 - [ ] MCP tool calls work through the tool execution loop

--- a/docs/frontend/backlog.md
+++ b/docs/frontend/backlog.md
@@ -56,7 +56,7 @@ These gaps were prioritized previously and are now mostly delivered based on cha
 
 ## Phase 2 — Plugin Ecosystem (THE DIFFERENTIATOR)
 
-This is what makes Estela "The Obsidian of AI Coding".
+This is what makes AVA "The Obsidian of AI Coding".
 
 ### Sprint 2.1: Plugin Format & SDK
 - [ ] Define unified plugin manifest (skills + commands + hooks + MCP in one package)
@@ -138,7 +138,7 @@ These were identified as gaps but are now fully implemented:
 
 ---
 
-## Unique Advantages (Estela vs Everyone)
+## Unique Advantages (AVA vs Everyone)
 
 Features no other AI coding tool has:
 

--- a/docs/frontend/design-system.md
+++ b/docs/frontend/design-system.md
@@ -1,4 +1,4 @@
-# Estela Design System 2026
+# AVA Design System 2026
 
 > Modern, minimal, dark-first design inspired by Cursor, Windsurf, Zed, and 2026 UI trends.
 
@@ -569,7 +569,7 @@ Each provider gets a custom icon with branded color:
 
 ### Desktop-First
 
-Estela is a desktop app, so we design desktop-first:
+AVA is a desktop app, so we design desktop-first:
 
 1. Full sidebar visible by default
 2. Multi-panel layouts

--- a/docs/research/cline/01-core-api-controller.md
+++ b/docs/research/cline/01-core-api-controller.md
@@ -233,7 +233,7 @@ Supports:
 
 ---
 
-## Notable Features for Estela
+## Notable Features for AVA
 
 ### 1. Multi-Provider Architecture at Scale
 Factory pattern for 40+ providers with unified interface.

--- a/docs/research/cline/02-prompts-permissions.md
+++ b/docs/research/cline/02-prompts-permissions.md
@@ -210,7 +210,7 @@ Result: DENIED (segment "nc attacker.com 1234" not in allow list)
 
 ---
 
-## Notable Features for Estela
+## Notable Features for AVA
 
 ### 1. Chained Command Validation
 Validates EACH segment of piped/chained commands.

--- a/docs/research/cline/03-tasks-hooks.md
+++ b/docs/research/cline/03-tasks-hooks.md
@@ -192,7 +192,7 @@ interface HookExecution {
 
 ---
 
-## Notable Features for Estela
+## Notable Features for AVA
 
 ### 1. Dual-Phase Tool Execution (Partial + Complete)
 Tools have `handlePartialBlock()` for streaming UI + `execute()` for completion.

--- a/docs/research/cline/04-services.md
+++ b/docs/research/cline/04-services.md
@@ -159,7 +159,7 @@ class Service {
 
 ---
 
-## Notable Features for Estela
+## Notable Features for AVA
 
 ### 1. Remote Browser Support
 Robust remote Chrome debugging via WebSocket + auto-discovery.

--- a/docs/research/cline/05-integrations.md
+++ b/docs/research/cline/05-integrations.md
@@ -206,7 +206,7 @@ src/file.ts
 
 ---
 
-## Notable Features for Estela
+## Notable Features for AVA
 
 ### 1. Checkpoint System
 Version control for changes without repo interference.

--- a/docs/research/cline/06-webview-ui.md
+++ b/docs/research/cline/06-webview-ui.md
@@ -219,7 +219,7 @@ groupLowStakesTools() → collapses non-critical tools
 
 ---
 
-## Notable Features for Estela
+## Notable Features for AVA
 
 ### 1. Advanced Input Handling
 - Drag-drop from VSCode Explorer (URI parsing)

--- a/docs/research/cline/07-cli-standalone.md
+++ b/docs/research/cline/07-cli-standalone.md
@@ -210,7 +210,7 @@ Standalone:
 
 ---
 
-## Notable Features for Estela
+## Notable Features for AVA
 
 ### 1. ACP (Agent Client Protocol)
 Programmatic agent interface for editor integration.

--- a/docs/research/cline/08-types-utilities.md
+++ b/docs/research/cline/08-types-utilities.md
@@ -282,7 +282,7 @@ Strategy:
 
 ---
 
-## Notable Features for Estela
+## Notable Features for AVA
 
 ### 1. Extended Thinking & Reasoning Support
 `reasoning_details` field for extended thinking content.

--- a/docs/research/cline/COMPARISON.md
+++ b/docs/research/cline/COMPARISON.md
@@ -1,4 +1,4 @@
-# Cline vs Estela Feature Comparison
+# Cline vs AVA Feature Comparison
 
 > Comprehensive feature matrix identifying gaps and opportunities
 
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-After comprehensive analysis of the Cline codebase (~150+ files examined), this document identifies **key features** that Estela could adopt or improve upon. Cline is a mature, enterprise-ready VS Code extension with sophisticated patterns for multi-provider support, approval workflows, and extensibility.
+After comprehensive analysis of the Cline codebase (~150+ files examined), this document identifies **key features** that AVA could adopt or improve upon. Cline is a mature, enterprise-ready VS Code extension with sophisticated patterns for multi-provider support, approval workflows, and extensibility.
 
 ---
 
@@ -14,7 +14,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### Provider Support
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | Provider Count | 40+ | ~10 | **Major** |
 | Provider Factory Pattern | ✅ | ✅ | - |
@@ -25,19 +25,19 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### Tools & Execution
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | Tool Count | 25+ | 19 | Minor |
-| Batch Tool | ❌ | ✅ | Estela ahead |
-| Multi-Edit Tool | ❌ | ✅ | Estela ahead |
-| Fuzzy Edit Strategies | ❌ | ✅ | Estela ahead |
+| Batch Tool | ❌ | ✅ | AVA ahead |
+| Multi-Edit Tool | ❌ | ✅ | AVA ahead |
+| Fuzzy Edit Strategies | ❌ | ✅ | AVA ahead |
 | Dual-Phase Execution (Partial + Complete) | ✅ | ❌ | **Medium** |
 | Tool Handler Registry | ✅ | ✅ | - |
 | Read-Only Tool Classification | ✅ | ❌ | **Minor** |
 
 ### Permissions & Safety
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | Permission System | ✅ (glob patterns) | ✅ | - |
 | Chained Command Validation | ✅ (per-segment) | ❌ | **Medium** |
@@ -49,7 +49,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### Hooks & Lifecycle
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | Hook System | ✅ (8 hooks) | ❌ | **Major** |
 | PreToolUse/PostToolUse | ✅ | ❌ | **Major** |
@@ -60,7 +60,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### System Prompts
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | Model-Family Variants | ✅ (8+ variants) | Basic | **Medium** |
 | Component Overrides | ✅ | ❌ | **Minor** |
@@ -70,7 +70,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### Context Management
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | Task Summarization | ✅ (10 sections) | Basic | **Medium** |
 | Focus Chain (Task Progress) | ✅ | ✅ (todo list) | - |
@@ -80,7 +80,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### Services
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | Remote Browser Support | ✅ | ❌ | **Major** |
 | MCP OAuth Support | ✅ | ❌ | **Major** |
@@ -92,7 +92,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### Integrations
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | Checkpoint System (Shadow Git) | ✅ | ❌ | **Major** |
 | Distributed Locking | ✅ | ❌ | **Medium** |
@@ -105,7 +105,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### UI/UX (Webview)
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | Virtual Scrolling | ✅ (Virtuoso) | ❌ | **Medium** |
 | gRPC Communication | ✅ | ❌ | **Major** |
@@ -118,7 +118,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### CLI & Standalone
 
-| Feature | Cline | Estela | Gap |
+| Feature | Cline | AVA | Gap |
 |---------|-------|--------|-----|
 | CLI with React Ink | ✅ | Terminal-based | Different |
 | ACP (Agent Client Protocol) | ✅ | ❌ | **Medium** |
@@ -164,7 +164,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ---
 
-## Where Estela is Ahead
+## Where AVA is Ahead
 
 1. **Batch Tool** - Execute up to 25 tools in parallel
 2. **Multi-Edit Tool** - Multiple sequential edits in one call
@@ -180,7 +180,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### Communication Pattern
 
-| Aspect | Cline | Estela |
+| Aspect | Cline | AVA |
 |--------|-------|--------|
 | Webview-Extension | gRPC (protobuf) | Direct calls |
 | Streaming | gRPC streaming | AsyncGenerator |
@@ -189,7 +189,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### State Management
 
-| Aspect | Cline | Estela |
+| Aspect | Cline | AVA |
 |--------|-------|--------|
 | Storage | StateManager + Secrets | SQLite + Memory |
 | State Keys | Central registry (118 fields) | Distributed |
@@ -198,7 +198,7 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ### Tool Execution
 
-| Aspect | Cline | Estela |
+| Aspect | Cline | AVA |
 |--------|-------|--------|
 | Registry | ToolExecutorCoordinator | Tool Registry |
 | Handlers | IFullyManagedTool interface | Tool functions |
@@ -236,10 +236,10 @@ After comprehensive analysis of the Cline codebase (~150+ files examined), this 
 
 ## Conclusion
 
-Cline has invested heavily in **enterprise features** (OAuth, remote browser, checkpoints) and **safety mechanisms** (chained validation, hook system, diagnostics tracking). Estela has stronger **tool execution capabilities** (batch, multi-edit, fuzzy strategies) and **knowledge systems** (skills, code search).
+Cline has invested heavily in **enterprise features** (OAuth, remote browser, checkpoints) and **safety mechanisms** (chained validation, hook system, diagnostics tracking). AVA has stronger **tool execution capabilities** (batch, multi-edit, fuzzy strategies) and **knowledge systems** (skills, code search).
 
 The recommended approach is to:
 1. Adopt Cline's safety patterns (hooks, validation)
 2. Adopt Cline's enterprise features (OAuth, checkpoints)
-3. Keep Estela's tool advantages (batch, fuzzy edits)
+3. Keep AVA's tool advantages (batch, fuzzy edits)
 4. Implement missing UI patterns (virtual scroll, message grouping)

--- a/docs/research/cline/README.md
+++ b/docs/research/cline/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Cline is a VS Code extension that provides AI-powered coding assistance. This analysis documents its architecture, patterns, and features to identify what Estela can learn from or adopt.
+Cline is a VS Code extension that provides AI-powered coding assistance. This analysis documents its architecture, patterns, and features to identify what AVA can learn from or adopt.
 
 **Source:** `docs/reference-code/cline/`
 **Version Analyzed:** Latest as of February 2026
@@ -25,7 +25,7 @@ Cline is a VS Code extension that provides AI-powered coding assistance. This an
 | 06 | [Webview UI](./06-webview-ui.md) | React components, state management |
 | 07 | [CLI & Standalone](./07-cli-standalone.md) | CLI commands, standalone app |
 | 08 | [Types & Utilities](./08-types-utilities.md) | Type definitions, shared utilities |
-| 09 | [Comparison](./COMPARISON.md) | Cline vs Estela feature comparison |
+| 09 | [Comparison](./COMPARISON.md) | Cline vs AVA feature comparison |
 
 ---
 
@@ -102,7 +102,7 @@ cline/
 
 ## Key Findings
 
-### What Cline Has That Estela Should Adopt
+### What Cline Has That AVA Should Adopt
 
 **Critical:**
 1. **Hook System** - 8 lifecycle hooks with subprocess isolation
@@ -118,7 +118,7 @@ cline/
 9. Diagnostics tracking (pre/post edit)
 10. Virtual scrolling for large histories
 
-### Where Estela is Ahead
+### Where AVA is Ahead
 
 1. **Batch Tool** - Execute up to 25 tools in parallel
 2. **Multi-Edit Tool** - Multiple sequential edits

--- a/docs/research/gemini-cli/A2A-ACP-RESEARCH.md
+++ b/docs/research/gemini-cli/A2A-ACP-RESEARCH.md
@@ -1,6 +1,6 @@
 # A2A & ACP Protocol Research
 
-> Deep research into Agent-to-Agent and Agent Client Protocol for Estela implementation
+> Deep research into Agent-to-Agent and Agent Client Protocol for AVA implementation
 
 ---
 
@@ -10,9 +10,9 @@ The AI agent ecosystem has converged on three complementary protocols:
 
 | Protocol | Focus | Transport | Status |
 |----------|-------|-----------|--------|
-| **MCP** (Anthropic) | Agent ↔ Tool | JSON-RPC over stdio/HTTP | Estela has this |
-| **ACP** (Zed/JetBrains) | Agent ↔ Editor | JSON-RPC over stdio | New for Estela |
-| **A2A** (Google/Linux Foundation) | Agent ↔ Agent | HTTP/SSE/gRPC | New for Estela |
+| **MCP** (Anthropic) | Agent ↔ Tool | JSON-RPC over stdio/HTTP | AVA has this |
+| **ACP** (Zed/JetBrains) | Agent ↔ Editor | JSON-RPC over stdio | New for AVA |
+| **A2A** (Google/Linux Foundation) | Agent ↔ Agent | HTTP/SSE/gRPC | New for AVA |
 
 ```
                     ┌──────────────┐
@@ -22,7 +22,7 @@ The AI agent ecosystem has converged on three complementary protocols:
                            │ ACP (JSON-RPC over stdio)
                            │
                     ┌──────▼───────┐
-                    │   Estela     │
+                    │   AVA     │
                     │  (AI Agent)  │
                     └──┬───────┬───┘
                        │       │
@@ -53,7 +53,7 @@ Every A2A agent publishes a JSON file at `/.well-known/agent.json`:
 
 ```json
 {
-  "name": "Estela Coding Agent",
+  "name": "AVA Coding Agent",
   "description": "AI coding assistant with browser automation, fuzzy edits, and parallel execution",
   "url": "http://localhost:41242/",
   "protocolVersion": "0.3.0",
@@ -170,9 +170,9 @@ data: {"taskId":"t1","status":{"state":"completed","message":{"role":"agent","pa
    - Maintains contextId/taskId for continuity
    - Extracts text from parts for LLM consumption
 
-### What Estela Needs
+### What AVA Needs
 
-**A2A Server** (expose Estela as an agent):
+**A2A Server** (expose AVA as an agent):
 - Agent Card at `/.well-known/agent.json`
 - HTTP/REST endpoints for messages, tasks, streaming
 - Task lifecycle management
@@ -193,7 +193,7 @@ data: {"taskId":"t1","status":{"state":"completed","message":{"role":"agent","pa
 ACP is a protocol for connecting AI coding agents to code editors. Think of it as **LSP for AI agents** - any agent can work in any supporting editor.
 
 **Key participants:**
-- **Agent** (Estela): Processes prompts, executes tools, modifies code
+- **Agent** (AVA): Processes prompts, executes tools, modifies code
 - **Client** (Editor): Manages UI, file access, terminal, permissions
 
 ### Protocol Specification
@@ -267,7 +267,7 @@ Client                          Agent
 // Agent → Client (initialize response)
 {
   "protocolVersion": 1,
-  "agentName": "Estela",
+  "agentName": "AVA",
   "agentVersion": "1.0.0",
   "capabilities": {
     "streaming": true,
@@ -327,7 +327,7 @@ class AcpFileSystemService implements FileSystemService {
 | goose | Supported |
 | StackPack | Supported |
 
-### What Estela Needs
+### What AVA Needs
 
 1. **ACP Agent Implementation** - Handle JSON-RPC over stdin/stdout
 2. **Session Management** - Create, prompt, cancel sessions
@@ -341,7 +341,7 @@ class AcpFileSystemService implements FileSystemService {
 
 ### Why ACP First
 
-1. **Immediate user value** - Estela works in Zed, JetBrains, Neovim
+1. **Immediate user value** - AVA works in Zed, JetBrains, Neovim
 2. **Simpler protocol** - JSON-RPC over stdio, no HTTP server needed
 3. **Complementary to existing CLI** - Just a new mode
 4. **SDK available** - `@agentclientprotocol/sdk` (TypeScript)

--- a/docs/research/gemini-cli/COMPARISON.md
+++ b/docs/research/gemini-cli/COMPARISON.md
@@ -1,4 +1,4 @@
-# Gemini CLI vs Estela: Comparison & Feature Gaps
+# Gemini CLI vs AVA: Comparison & Feature Gaps
 
 > Comprehensive comparison based on full codebase analysis of Gemini CLI
 
@@ -6,12 +6,12 @@
 
 ## Executive Summary
 
-Gemini CLI is a production-grade AI coding assistant built on React + Ink for terminal UI. After analyzing all 5 packages (~150+ files), several architectural patterns and features could enhance Estela.
+Gemini CLI is a production-grade AI coding assistant built on React + Ink for terminal UI. After analyzing all 5 packages (~150+ files), several architectural patterns and features could enhance AVA.
 
 **Key Findings:**
 - Gemini CLI has **more mature infrastructure** (policy engine, message bus, extension system)
-- Estela has **unique strengths** (browser automation, Tauri desktop, SolidJS)
-- Several **high-value features** are missing from Estela
+- AVA has **unique strengths** (browser automation, Tauri desktop, SolidJS)
+- Several **high-value features** are missing from AVA
 
 ---
 
@@ -31,7 +31,7 @@ Gemini CLI is a production-grade AI coding assistant built on React + Ink for te
 
 ## Architecture Comparison
 
-| Aspect | Gemini CLI | Estela |
+| Aspect | Gemini CLI | AVA |
 |--------|------------|--------|
 | **UI Framework** | React + Ink (terminal) | SolidJS + Tauri (desktop) |
 | **Runtime** | Node.js CLI | Tauri (Rust + Web) |
@@ -49,7 +49,7 @@ Gemini CLI is a production-grade AI coding assistant built on React + Ink for te
 
 ### Critical Gaps (High Impact)
 
-| Feature | Gemini CLI | Estela | Priority |
+| Feature | Gemini CLI | AVA | Priority |
 |---------|------------|--------|----------|
 | **Policy Engine** | Priority-based rules, wildcards, regex | Simple auto-approve list | 🔴 High |
 | **Message Bus** | Decoupled tool/UI, correlation IDs | Tight coupling | 🔴 High |
@@ -58,7 +58,7 @@ Gemini CLI is a production-grade AI coding assistant built on React + Ink for te
 
 ### Important Gaps (Medium Impact)
 
-| Feature | Gemini CLI | Estela | Priority |
+| Feature | Gemini CLI | AVA | Priority |
 |---------|------------|--------|----------|
 | **Chat Compression** | LLM summarization with verification | Basic token compaction | 🟡 Medium |
 | **PTY Shell** | xterm with 300K scrollback | Basic spawn | 🟡 Medium |
@@ -69,7 +69,7 @@ Gemini CLI is a production-grade AI coding assistant built on React + Ink for te
 
 ### Nice-to-Have Gaps (Lower Impact)
 
-| Feature | Gemini CLI | Estela | Priority |
+| Feature | Gemini CLI | AVA | Priority |
 |---------|------------|--------|----------|
 | **A2A Protocol** | Multi-agent REST API | None | 🟢 Low |
 | **Agent Cards** | `.well-known/agent-card.json` | None | 🟢 Low |
@@ -78,9 +78,9 @@ Gemini CLI is a production-grade AI coding assistant built on React + Ink for te
 
 ---
 
-## What Estela Does Better
+## What AVA Does Better
 
-| Feature | Estela Advantage |
+| Feature | AVA Advantage |
 |---------|------------------|
 | **Browser Automation** | Built-in Puppeteer tool, not in Gemini CLI |
 | **Desktop App** | Native Tauri app with SolidJS |
@@ -224,7 +224,7 @@ Exit codes control behavior:
 
 ## Code Statistics
 
-| Component | Gemini CLI | Estela |
+| Component | Gemini CLI | AVA |
 |-----------|------------|--------|
 | Core Package | ~25K lines | ~25K lines |
 | CLI/Frontend | ~15K lines | ~5K lines |

--- a/docs/research/gemini-cli/a2a-server.md
+++ b/docs/research/gemini-cli/a2a-server.md
@@ -782,9 +782,9 @@ enum ToolConfirmationOutcome {
 
 ---
 
-## Key Takeaways for Estela
+## Key Takeaways for AVA
 
-### Features Estela Might Be Missing
+### Features AVA Might Be Missing
 
 1. **A2A Protocol Support**
    - Standardized agent-to-agent communication
@@ -863,9 +863,9 @@ enum ToolConfirmationOutcome {
 
 ---
 
-## Comparison with Estela
+## Comparison with AVA
 
-| Feature | Gemini A2A | Estela | Gap |
+| Feature | Gemini A2A | AVA | Gap |
 |---------|------------|--------|-----|
 | Agent-to-Agent Protocol | Yes (A2A 0.3) | No | Missing |
 | Task Persistence | GCS + InMemory | SQLite | Similar |
@@ -882,7 +882,7 @@ enum ToolConfirmationOutcome {
 ## Recommendations
 
 1. **Consider A2A Protocol Support**
-   - Would enable Estela to be controlled by other AI agents
+   - Would enable AVA to be controlled by other AI agents
    - Useful for multi-agent orchestration scenarios
    - SDK available (`@a2a-js/sdk`)
 

--- a/docs/research/gemini-cli/cli.md
+++ b/docs/research/gemini-cli/cli.md
@@ -870,14 +870,14 @@ Extension Structure:
 
 ---
 
-## Key Takeaways for Estela
+## Key Takeaways for AVA
 
 ### Features to Consider
 
 1. **Extension System**
    - Gemini CLI has a sophisticated extension system supporting GitHub, local, and linked extensions
    - Extensions can provide: commands, MCP servers, skills, themes, hooks
-   - Estela could benefit from a similar plugin architecture
+   - AVA could benefit from a similar plugin architecture
 
 2. **Session Resume**
    - Full session resume with `--resume latest` or `--resume <id>`
@@ -888,7 +888,7 @@ Extension Structure:
    - `--yolo` for full automation
    - `--auto-edit` for edit-only automation
    - `--plan` for planning mode
-   - Estela should consider similar granular approval controls
+   - AVA should consider similar granular approval controls
 
 4. **Sandbox Execution**
    - Built-in support for Docker, Podman, sandbox-exec
@@ -947,7 +947,7 @@ Extension Structure:
    - Centralized cleanup with sync and async handlers
    - Telemetry shutdown as final step
 
-### Missing in Estela (Potential Gaps)
+### Missing in AVA (Potential Gaps)
 
 1. **Session Browser UI** - Interactive session selection
 2. **Extension Marketplace** - GitHub-based extension discovery

--- a/docs/research/gemini-cli/core.md
+++ b/docs/research/gemini-cli/core.md
@@ -2,7 +2,7 @@
 
 **Analysis Date**: 2026-02-04
 **Package Path**: `docs/reference-code/gemini-cli/packages/core/src/`
-**Purpose**: Comprehensive analysis of Gemini CLI's core architecture for Estela reference
+**Purpose**: Comprehensive analysis of Gemini CLI's core architecture for AVA reference
 
 ---
 
@@ -850,9 +850,9 @@ Chat compression uses:
 
 ---
 
-## Key Takeaways for Estela
+## Key Takeaways for AVA
 
-### Features Estela Should Consider
+### Features AVA Should Consider
 
 1. **Hook System**
    - Gemini CLI's command-based hooks (shell scripts with JSON I/O) are simple yet powerful
@@ -891,7 +891,7 @@ Chat compression uses:
 
 ### Architecture Differences
 
-| Aspect | Gemini CLI | Estela (Current) |
+| Aspect | Gemini CLI | AVA (Current) |
 |--------|------------|------------------|
 | Tool Approval | Message Bus + Policy Engine | Direct confirmation |
 | Hooks | Command-based (shell) | TypeScript functions |

--- a/docs/research/gemini-cli/root-configs.md
+++ b/docs/research/gemini-cli/root-configs.md
@@ -1,6 +1,6 @@
 # Gemini CLI Root Configs Analysis
 
-> Comprehensive analysis of Gemini CLI's root-level files and configurations for Estela reference.
+> Comprehensive analysis of Gemini CLI's root-level files and configurations for AVA reference.
 
 ---
 
@@ -430,7 +430,7 @@ Uses a forked version of Ink (`@jrichman/ink`) for custom features or fixes.
 
 ---
 
-## Key Takeaways for Estela
+## Key Takeaways for AVA
 
 ### What to Adopt
 
@@ -445,9 +445,9 @@ Uses a forked version of Ink (`@jrichman/ink`) for custom features or fixes.
 9. **Environment isolation**: Wrappers for `homedir()`/`tmpdir()`
 10. **License headers**: Enforced via ESLint plugin
 
-### Differences from Estela
+### Differences from AVA
 
-| Aspect | Gemini CLI | Estela |
+| Aspect | Gemini CLI | AVA |
 |--------|------------|--------|
 | UI Framework | React (Ink) for CLI | SolidJS for Tauri |
 | Platform | Node.js CLI only | Tauri desktop + CLI |

--- a/docs/research/gemini-cli/vscode-extension.md
+++ b/docs/research/gemini-cli/vscode-extension.md
@@ -2,7 +2,7 @@
 
 > Analysis of the Gemini CLI Companion VS Code Extension architecture and patterns.
 
-**Source Location:** `/home/xn3/Projects/Personal/Estela/docs/reference-code/gemini-cli/packages/vscode-ide-companion/`
+**Source Location:** `/home/xn3/Projects/Personal/AVA/docs/reference-code/gemini-cli/packages/vscode-ide-companion/`
 
 ---
 
@@ -687,9 +687,9 @@ Special handling for Firebase Studio, Cloud Shell, etc.:
 
 ---
 
-## Implications for Estela
+## Implications for AVA
 
-For Estela's VS Code extension implementation, consider:
+For AVA's VS Code extension implementation, consider:
 
 1. **Use MCP** - Provides standardized tooling and is becoming an industry standard
 2. **Environment Variable Injection** - Most reliable discovery mechanism

--- a/docs/research/opencode/02-providers.md
+++ b/docs/research/opencode/02-providers.md
@@ -611,7 +611,7 @@ if ("refresh" in result) {
 
 ---
 
-## Key Takeaways for Estela
+## Key Takeaways for AVA
 
 1. **Use AI SDK abstractions**: OpenCode builds on Vercel AI SDK, providing a clean abstraction layer
 

--- a/docs/research/opencode/04-config-project.md
+++ b/docs/research/opencode/04-config-project.md
@@ -36,7 +36,7 @@
 9. [Instructions System](#instructions-system)
 10. [Skills & Plugins](#skills--plugins)
 11. [Authentication Storage](#authentication-storage)
-12. [Key Takeaways for Estela](#key-takeaways-for-estela)
+12. [Key Takeaways for AVA](#key-takeaways-for-estela)
 
 ---
 
@@ -905,7 +905,7 @@ export async function set(key: string, info: Info) {
 
 ---
 
-## Key Takeaways for Estela
+## Key Takeaways for AVA
 
 ### Configuration Best Practices
 

--- a/docs/research/opencode/07-auxiliary-packages.md
+++ b/docs/research/opencode/07-auxiliary-packages.md
@@ -1148,7 +1148,7 @@ const desktopPlatform: Platform = {
 
 ---
 
-## Key Takeaways for Estela
+## Key Takeaways for AVA
 
 ### Desktop App Patterns
 

--- a/docs/research/opencode/COMPARISON.md
+++ b/docs/research/opencode/COMPARISON.md
@@ -1,4 +1,4 @@
-# OpenCode vs Estela Feature Comparison
+# OpenCode vs AVA Feature Comparison
 
 > Comprehensive comparison based on thorough OpenCode codebase analysis
 
@@ -7,8 +7,8 @@
 ## Executive Summary
 
 After analyzing ~178KB of documentation covering every aspect of OpenCode's codebase, this document identifies:
-- **Critical missing features** in Estela
-- **Estela advantages** over OpenCode
+- **Critical missing features** in AVA
+- **AVA advantages** over OpenCode
 - **Architecture differences** worth considering
 - **Recommended action items** prioritized by impact
 
@@ -18,7 +18,7 @@ After analyzing ~178KB of documentation covering every aspect of OpenCode's code
 
 ### OpenCode Tools (20 total)
 
-| Tool | Description | Estela Equivalent |
+| Tool | Description | AVA Equivalent |
 |------|-------------|-------------------|
 | `read` | Read files with line numbers | `read_file` ✅ |
 | `write` | Overwrite files | `write_file` ✅ |
@@ -43,7 +43,7 @@ After analyzing ~178KB of documentation covering every aspect of OpenCode's code
 | `lsp` | LSP operations (experimental) | ⚠️ In progress |
 | `invalid` | Error handling for malformed calls | ⚠️ Implicit |
 
-### Estela-Only Tools
+### AVA-Only Tools
 
 | Tool | Description | OpenCode Equivalent |
 |------|-------------|---------------------|
@@ -195,7 +195,7 @@ Combines multiple edits to a single file:
 
 ### Key Provider Features
 
-| Feature | OpenCode | Estela |
+| Feature | OpenCode | AVA |
 |---------|----------|--------|
 | Prompt caching (Anthropic) | ✅ Ephemeral | ⚠️ Verify |
 | Responses API (OpenAI) | ✅ Custom SDK | ⚠️ Verify |
@@ -221,7 +221,7 @@ Combines multiple edits to a single file:
 
 ### Transport Types
 
-| Transport | OpenCode | Estela |
+| Transport | OpenCode | AVA |
 |-----------|----------|--------|
 | Local (stdio) | ✅ | ✅ |
 | HTTP (streamable) | ✅ | ⚠️ Verify |
@@ -230,7 +230,7 @@ Combines multiple edits to a single file:
 
 ### MCP Features
 
-| Feature | OpenCode | Estela |
+| Feature | OpenCode | AVA |
 |---------|----------|--------|
 | Tool integration | ✅ Automatic | ⚠️ Verify |
 | Resource reading | ✅ | ⚠️ Verify |
@@ -263,7 +263,7 @@ Combines multiple edits to a single file:
 - Per-agent permission overrides
 - Session-level permission merging
 
-### Estela Permission Model
+### AVA Permission Model
 
 Location: `packages/core/src/permissions/`
 
@@ -302,7 +302,7 @@ pending → running → completed | error
 - Prunes old tool outputs (keeps last 40k tokens)
 - Protected tools: `["skill"]`
 
-### Estela Session Model
+### AVA Session Model
 
 Location: `packages/core/src/session/`
 
@@ -340,7 +340,7 @@ Location: `packages/core/src/session/`
 - `documentSymbol`, `workspaceSymbol`
 - `prepareCallHierarchy`, `incomingCalls`, `outgoingCalls`
 
-### Estela LSP
+### AVA LSP
 
 Location: `packages/core/src/lsp/`
 
@@ -368,7 +368,7 @@ Location: `packages/core/src/lsp/`
 - Step limits
 - Color/visibility
 
-### Estela Agent System
+### AVA Agent System
 
 Location: `packages/core/src/agent/`
 
@@ -387,7 +387,7 @@ Based on CLAUDE.md: Similar subagent architecture with `task` tool delegation.
 - Real-time streaming
 - Permission dialogs
 
-### Estela TUI
+### AVA TUI
 
 Location: `cli/` and `src/` (SolidJS Tauri frontend)
 
@@ -407,7 +407,7 @@ Location: `cli/` and `src/` (SolidJS Tauri frontend)
 | `Snapshot.restore()` | Restore specific snapshot |
 | Session revert | Undo to message/part |
 
-### Estela Snapshot System
+### AVA Snapshot System
 
 Location: `packages/core/src/git/`
 
@@ -425,7 +425,7 @@ Location: `packages/core/src/git/`
 - Session management API
 - Workspace operations
 
-### Estela SDK
+### AVA SDK
 
 **Status:** Internal use in `packages/core/`
 
@@ -542,9 +542,9 @@ const context: Tool.Context = {
 
 ---
 
-## Estela Advantages
+## AVA Advantages
 
-| Feature | Estela | OpenCode |
+| Feature | AVA | OpenCode |
 |---------|--------|----------|
 | Browser Automation | ✅ Puppeteer tool | ❌ |
 | Native Desktop App | ✅ Tauri + SolidJS | ❌ Terminal only |
@@ -572,13 +572,13 @@ This analysis generated 7 comprehensive documents:
 
 ## Conclusion
 
-OpenCode has several mature features worth porting to Estela:
+OpenCode has several mature features worth porting to AVA:
 
 1. **Batch tool** - Significant performance improvement
 2. **Fuzzy edit strategies** - Critical for reliability
 3. **Skill system** - Extensibility pattern
 4. **Doom loop detection** - Safety feature
 
-Estela has unique advantages in browser automation and native desktop experience that OpenCode lacks.
+AVA has unique advantages in browser automation and native desktop experience that OpenCode lacks.
 
 **Recommended approach:** Prioritize batch tool and fuzzy edits first, as they directly improve daily usage reliability and performance.

--- a/docs/research/opencode/README.md
+++ b/docs/research/opencode/README.md
@@ -1,6 +1,6 @@
 # OpenCode Analysis
 
-> Comprehensive analysis of the OpenCode codebase for comparison with Estela
+> Comprehensive analysis of the OpenCode codebase for comparison with AVA
 
 ## Documents
 
@@ -19,14 +19,14 @@
 
 ## Quick Reference
 
-### Critical Missing Features in Estela
+### Critical Missing Features in AVA
 
 1. **Batch Tool** - Parallel execution of up to 25 tools
 2. **Fuzzy Edit Strategies** - 9 strategies for reliable text replacement
 3. **Skill System** - Reusable knowledge modules
 4. **Doom Loop Detection** - Safety feature for repeated identical calls
 
-### Estela Advantages
+### AVA Advantages
 
 - Browser automation (Puppeteer)
 - Native desktop app (Tauri + SolidJS)

--- a/docs/research/pi-coding-agent.md
+++ b/docs/research/pi-coding-agent.md
@@ -1,10 +1,10 @@
 # PI Coding Agent — Research Notes
 
-> Analysis of PI Coding Agent architecture and philosophy, with comparison to Estela's approach.
+> Analysis of PI Coding Agent architecture and philosophy, with comparison to AVA's approach.
 
 ## Overview
 
-PI Coding Agent is a minimalist AI coding assistant built on the principle of radical simplicity. Where Estela uses a multi-agent delegation hierarchy (Team Lead, Senior Leads, Junior Devs), PI takes the opposite approach: a single agent with minimal tools that can self-extend at runtime.
+PI Coding Agent is a minimalist AI coding assistant built on the principle of radical simplicity. Where AVA uses a multi-agent delegation hierarchy (Team Lead, Senior Leads, Junior Devs), PI takes the opposite approach: a single agent with minimal tools that can self-extend at runtime.
 
 **Repository**: Open source, installed via npm
 **Architecture**: Single-agent, tool-minimal, cross-provider
@@ -13,7 +13,7 @@ PI Coding Agent is a minimalist AI coding assistant built on the principle of ra
 
 ## Core Philosophy: Radical Minimalism
 
-PI's defining characteristic is its extreme tool reduction. While most coding agents (Claude Code, Cursor, Estela) provide 15-25+ tools, PI ships with only **4 core tools**:
+PI's defining characteristic is its extreme tool reduction. While most coding agents (Claude Code, Cursor, AVA) provide 15-25+ tools, PI ships with only **4 core tools**:
 
 | Tool | Purpose |
 |------|---------|
@@ -24,11 +24,11 @@ PI's defining characteristic is its extreme tool reduction. While most coding ag
 
 Everything else — editing, diffing, testing, linting, browsing — is done through these 4 primitives. File editing is `read` + `write`. Testing is `shell` with the test runner. This forces the LLM to compose operations from primitives rather than relying on specialized tools.
 
-### Implications for Estela
+### Implications for AVA
 
-Estela's 22 tools include specialized ones like `edit` (8 fuzzy strategies), `codesearch`, `batch`, `multiedit`, `browser`. These provide better UX and fewer LLM errors at the cost of complexity. The question is: does tool specialization justify the prompt engineering overhead?
+AVA's 22 tools include specialized ones like `edit` (8 fuzzy strategies), `codesearch`, `batch`, `multiedit`, `browser`. These provide better UX and fewer LLM errors at the cost of complexity. The question is: does tool specialization justify the prompt engineering overhead?
 
-**Takeaway**: Consider a "minimal mode" for Estela where only core tools are exposed, reducing token usage and latency for simple tasks.
+**Takeaway**: Consider a "minimal mode" for AVA where only core tools are exposed, reducing token usage and latency for simple tasks.
 
 ---
 
@@ -43,9 +43,9 @@ PI's most innovative feature is **mid-session provider switching**. Users can ch
 3. User can switch providers at any point in the conversation
 4. Context follows seamlessly — new provider sees all previous messages
 
-### Implications for Estela
+### Implications for AVA
 
-Estela already has multi-provider support (14 providers) but provider switching is session-level. Adding mid-conversation provider switching would be a differentiator. Implementation path:
+AVA already has multi-provider support (14 providers) but provider switching is session-level. Adding mid-conversation provider switching would be a differentiator. Implementation path:
 - Store messages in provider-agnostic format (already done in database)
 - Add "Switch model" command in chat
 - Format history for new provider's API on next turn
@@ -72,9 +72,9 @@ Users can navigate between branches, compare outcomes, and merge results. This i
 - A/B testing prompts
 - Rolling back without losing the alternative attempt
 
-### Implications for Estela
+### Implications for AVA
 
-Estela has session fork (just added in Session 37) but it's a full copy, not a tree structure. A tree-based session model would:
+AVA has session fork (just added in Session 37) but it's a full copy, not a tree structure. A tree-based session model would:
 - Save storage (shared prefix messages aren't duplicated)
 - Enable visual branch comparison in the UI
 - Support "try both approaches" workflows
@@ -93,11 +93,11 @@ Agent: "I keep needing to check TypeScript types. Let me create a tool for that.
 → Tool is available for the rest of the session
 ```
 
-### Implications for Estela
+### Implications for AVA
 
-This maps to Estela's plugin/skill system. The key insight is **runtime skill creation** — letting the agent define new skills during a session rather than requiring pre-installation. This could work through:
+This maps to AVA's plugin/skill system. The key insight is **runtime skill creation** — letting the agent define new skills during a session rather than requiring pre-installation. This could work through:
 - Agent writes a TOML command definition
-- Estela's command system hot-reloads it
+- AVA's command system hot-reloads it
 - Tool is available immediately
 
 ---
@@ -106,9 +106,9 @@ This maps to Estela's plugin/skill system. The key insight is **runtime skill cr
 
 PI explicitly avoids multi-agent delegation. There's no planner/executor split, no task decomposition into sub-agents. The single agent handles everything sequentially.
 
-### Tradeoffs vs Estela
+### Tradeoffs vs AVA
 
-| Aspect | PI (Single Agent) | Estela (Multi-Agent) |
+| Aspect | PI (Single Agent) | AVA (Multi-Agent) |
 |--------|-------------------|---------------------|
 | Simplicity | Much simpler | Complex hierarchy |
 | Parallelism | None | Teams work in parallel |
@@ -118,11 +118,11 @@ PI explicitly avoids multi-agent delegation. There's no planner/executor split, 
 | Debugging | Easy to follow | Need team panel to track |
 | Specialization | General-purpose | Domain-specific prompts |
 
-PI's approach works well for individual developers on focused tasks. Estela's multi-agent approach targets larger, multi-domain tasks where parallelism and specialization provide value.
+PI's approach works well for individual developers on focused tasks. AVA's multi-agent approach targets larger, multi-domain tasks where parallelism and specialization provide value.
 
 ---
 
-## Lessons for Estela
+## Lessons for AVA
 
 1. **Mid-conversation provider switching** — High-value, medium-effort feature. Users could switch from Opus (expensive, smart) to Haiku (cheap, fast) mid-task.
 
@@ -130,7 +130,7 @@ PI's approach works well for individual developers on focused tasks. Estela's mu
 
 3. **Minimal mode** — Offer a "4-tool mode" for simple tasks that reduces token overhead and cost. Power users could toggle between full and minimal tool sets.
 
-4. **Runtime skill creation** — Let the agent create temporary tools during a session. Bridges PI's self-extension with Estela's plugin system.
+4. **Runtime skill creation** — Let the agent create temporary tools during a session. Bridges PI's self-extension with AVA's plugin system.
 
 5. **Provider-agnostic session state** — Ensure messages are stored in a format that doesn't assume a specific provider. This is mostly already done.
 
@@ -138,4 +138,4 @@ PI's approach works well for individual developers on focused tasks. Estela's mu
 
 ## Summary
 
-PI represents the "Unix philosophy" end of the AI coding agent spectrum: do one thing well, compose from primitives, stay simple. Estela sits at the other end: rich tooling, team delegation, visual hierarchy. Both approaches have merit. The key takeaways are features that could enhance Estela without changing its core architecture: provider switching, session branching, and minimal mode.
+PI represents the "Unix philosophy" end of the AI coding agent spectrum: do one thing well, compose from primitives, stay simple. AVA sits at the other end: rich tooling, team delegation, visual hierarchy. Both approaches have merit. The key takeaways are features that could enhance AVA without changing its core architecture: provider switching, session branching, and minimal mode.

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#0a0a0b" />
     <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/svg+xml" href="/src/assets/logo.svg" />
-    <title>Estela - AI Coding Assistant</title>
+    <title>AVA - AI Coding Assistant</title>
 
     <!-- Theme detection script - runs before render to prevent flash -->
     <script>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ava/core",
   "version": "0.1.0",
-  "description": "Core business logic for Estela - LLM client, tools, types",
+  "description": "Core business logic for AVA - LLM client, tools, types",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/a2a/agent-card.test.ts
+++ b/packages/core/src/a2a/agent-card.test.ts
@@ -11,7 +11,7 @@ describe('agent-card', () => {
     it('should create card with defaults', () => {
       const card = createAgentCard()
 
-      expect(card.name).toBe('Estela')
+      expect(card.name).toBe('AVA')
       expect(card.protocolVersion).toBe(A2A_PROTOCOL_VERSION)
       expect(card.version).toBe(DEFAULT_AGENT_VERSION)
       expect(card.url).toBe(`http://localhost:${DEFAULT_A2A_PORT}/`)
@@ -73,7 +73,7 @@ describe('agent-card', () => {
       const card = createAgentCard()
 
       expect(card.provider).toBeDefined()
-      expect(card.provider!.organization).toBe('Estela')
+      expect(card.provider!.organization).toBe('AVA')
     })
 
     it('should include input/output modes', () => {

--- a/packages/core/src/a2a/agent-card.ts
+++ b/packages/core/src/a2a/agent-card.ts
@@ -1,7 +1,7 @@
 /**
  * A2A Agent Card
  *
- * Describes Estela's capabilities for agent discovery.
+ * Describes AVA's capabilities for agent discovery.
  * Served at /.well-known/agent.json
  */
 
@@ -13,10 +13,10 @@ import { A2A_PROTOCOL_VERSION, DEFAULT_A2A_PORT, DEFAULT_AGENT_VERSION } from '.
 // ============================================================================
 
 /**
- * Create the Estela agent card for A2A discovery.
+ * Create the AVA agent card for A2A discovery.
  *
  * @param config - Server configuration
- * @returns AgentCard describing Estela's capabilities
+ * @returns AgentCard describing AVA's capabilities
  */
 export function createAgentCard(config: A2AServerConfig = {}): AgentCard {
   const port = config.port ?? DEFAULT_A2A_PORT
@@ -24,15 +24,15 @@ export function createAgentCard(config: A2AServerConfig = {}): AgentCard {
   const version = config.agentVersion ?? DEFAULT_AGENT_VERSION
 
   return {
-    name: 'Estela',
+    name: 'AVA',
     description:
       'Multi-agent AI coding assistant with browser automation, fuzzy edits, and parallel execution',
     url: `http://${host}:${port}/`,
     version,
     protocolVersion: A2A_PROTOCOL_VERSION,
     provider: {
-      organization: 'Estela',
-      url: 'https://github.com/estela-ai/estela',
+      organization: 'AVA',
+      url: 'https://github.com/g0dxn4/AVA',
     },
     capabilities: {
       streaming: true,

--- a/packages/core/src/a2a/index.ts
+++ b/packages/core/src/a2a/index.ts
@@ -1,7 +1,7 @@
 /**
  * A2A (Agent-to-Agent) Protocol
  *
- * Exposes Estela as an A2A-compatible agent over HTTP.
+ * Exposes AVA as an A2A-compatible agent over HTTP.
  *
  * @module a2a
  */

--- a/packages/core/src/a2a/server.test.ts
+++ b/packages/core/src/a2a/server.test.ts
@@ -89,7 +89,7 @@ describe('A2AServer', () => {
       const { status, body } = await fetchJson(`${baseUrl}/.well-known/agent.json`)
 
       expect(status).toBe(200)
-      expect(body.name).toBe('Estela')
+      expect(body.name).toBe('AVA')
       expect(body.protocolVersion).toBe(A2A_PROTOCOL_VERSION)
       expect(body.version).toBe(DEFAULT_AGENT_VERSION)
     })
@@ -105,7 +105,7 @@ describe('A2AServer', () => {
 
       const { status, body } = await fetchJson(`${url}/.well-known/agent.json`)
       expect(status).toBe(200)
-      expect(body.name).toBe('Estela')
+      expect(body.name).toBe('AVA')
     })
 
     it('should include capabilities', async () => {
@@ -126,7 +126,7 @@ describe('A2AServer', () => {
         body: JSON.stringify({
           message: {
             role: 'user',
-            parts: [{ type: 'text', text: 'Hello, Estela' }],
+            parts: [{ type: 'text', text: 'Hello, AVA' }],
           },
         }),
       })

--- a/packages/core/src/a2a/server.ts
+++ b/packages/core/src/a2a/server.ts
@@ -1,7 +1,7 @@
 /**
  * A2A HTTP Server
  *
- * Exposes Estela as an A2A-compatible agent over HTTP.
+ * Exposes AVA as an A2A-compatible agent over HTTP.
  * Uses Node's native http module (no Express dependency).
  *
  * Endpoints:

--- a/packages/core/src/a2a/task.ts
+++ b/packages/core/src/a2a/task.ts
@@ -2,7 +2,7 @@
  * A2A Task Manager
  *
  * Manages A2A task lifecycle: create, execute, cancel.
- * Bridges between A2A protocol and Estela's AgentExecutor.
+ * Bridges between A2A protocol and AVA's AgentExecutor.
  */
 
 import { randomUUID } from 'node:crypto'

--- a/packages/core/src/a2a/types.ts
+++ b/packages/core/src/a2a/types.ts
@@ -2,7 +2,7 @@
  * A2A Protocol Types
  *
  * Types for the Agent-to-Agent protocol (v0.3.0).
- * Allows Estela to be discovered and used by other AI agents over HTTP.
+ * Allows AVA to be discovered and used by other AI agents over HTTP.
  *
  * Reference: https://google.github.io/A2A/
  */
@@ -216,5 +216,5 @@ export const DEFAULT_A2A_PORT = 41242
 /** Default A2A protocol version */
 export const A2A_PROTOCOL_VERSION = '0.3.0'
 
-/** Default Estela agent version */
+/** Default AVA agent version */
 export const DEFAULT_AGENT_VERSION = '1.0.0'

--- a/packages/core/src/acp/index.ts
+++ b/packages/core/src/acp/index.ts
@@ -1,7 +1,7 @@
 /**
  * ACP (Agent Client Protocol) Module
  *
- * Production-quality ACP integration for Estela.
+ * Production-quality ACP integration for AVA.
  * Provides session persistence, terminal bridging, MCP forwarding,
  * mode switching, and error handling for editor integration.
  */

--- a/packages/core/src/acp/mcp-bridge.ts
+++ b/packages/core/src/acp/mcp-bridge.ts
@@ -1,7 +1,7 @@
 /**
  * ACP MCP Bridge
  *
- * Forwards MCP server configurations from the editor to Estela's
+ * Forwards MCP server configurations from the editor to AVA's
  * MCPClientManager. When an editor sends MCP server configs during
  * session creation, this bridge connects them automatically.
  */
@@ -16,10 +16,10 @@ import { AcpError, AcpErrorCode } from './types.js'
 // ============================================================================
 
 /**
- * Bridges editor MCP server configs to Estela's MCP client.
+ * Bridges editor MCP server configs to AVA's MCP client.
  *
  * When editors send MCP configs in `session/new`, this bridge:
- * 1. Converts ACP config format → Estela MCPServerConfig
+ * 1. Converts ACP config format → AVA MCPServerConfig
  * 2. Connects to each server via MCPClientManager
  * 3. Discovers tools from connected servers
  * 4. Makes tools available in the ACP session
@@ -167,7 +167,7 @@ export class AcpMCPBridge {
   // ==========================================================================
 
   /**
-   * Convert ACP MCP config to Estela MCPServerConfig
+   * Convert ACP MCP config to AVA MCPServerConfig
    */
   private normalizeConfig(config: AcpMCPServerConfig): MCPServerConfig {
     return {

--- a/packages/core/src/acp/mode.ts
+++ b/packages/core/src/acp/mode.ts
@@ -2,7 +2,7 @@
  * ACP Mode Switching
  *
  * Manages plan/agent mode switching for ACP sessions.
- * Integrates with Estela's plan mode system to restrict tools
+ * Integrates with AVA's plan mode system to restrict tools
  * when in plan mode.
  */
 

--- a/packages/core/src/acp/session-store.test.ts
+++ b/packages/core/src/acp/session-store.test.ts
@@ -37,10 +37,10 @@ describe('AcpSessionStore', () => {
       expect(session.status).toBe('active')
     })
 
-    it('should map ACP session ID to Estela session', async () => {
+    it('should map ACP session ID to AVA session', async () => {
       const session = await store.create('acp-2', '/tmp')
 
-      const estelaId = store.getEstelaId('acp-2')
+      const estelaId = store.getAVAId('acp-2')
       expect(estelaId).toBe(session.id)
     })
 
@@ -71,7 +71,7 @@ describe('AcpSessionStore', () => {
   })
 
   describe('load', () => {
-    it('should load a session by Estela ID', async () => {
+    it('should load a session by AVA ID', async () => {
       const created = await store.create('acp-load-1', '/tmp')
       const loaded = await store.load(created.id)
 
@@ -79,7 +79,7 @@ describe('AcpSessionStore', () => {
       expect(loaded!.id).toBe(created.id)
     })
 
-    it('should return null for unknown Estela ID', async () => {
+    it('should return null for unknown AVA ID', async () => {
       const result = await store.load('nonexistent')
       expect(result).toBeNull()
     })

--- a/packages/core/src/acp/session-store.ts
+++ b/packages/core/src/acp/session-store.ts
@@ -1,8 +1,8 @@
 /**
  * ACP Session Store
  *
- * Bridges ACP sessions to Estela's SessionManager for persistence.
- * Maps ACP session IDs to Estela session IDs and handles save/load/resume.
+ * Bridges ACP sessions to AVA's SessionManager for persistence.
+ * Maps ACP session IDs to AVA session IDs and handles save/load/resume.
  */
 
 import { createFileSessionStorage } from '../session/file-storage.js'
@@ -22,9 +22,9 @@ const ACP_SESSION_PREFIX = 'ACP: '
 // ============================================================================
 
 /**
- * Manages ACP session persistence using Estela's SessionManager.
+ * Manages ACP session persistence using AVA's SessionManager.
  *
- * - Maps ACP session IDs → Estela session IDs
+ * - Maps ACP session IDs → AVA session IDs
  * - Persists sessions to ~/.estela/sessions/
  * - Supports resume via `session/load`
  */
@@ -66,7 +66,7 @@ export class AcpSessionStore {
   }
 
   /**
-   * Get the Estela session for an ACP session ID
+   * Get the AVA session for an ACP session ID
    */
   async get(acpSessionId: string): Promise<SessionState | null> {
     this.ensureNotDisposed()
@@ -78,7 +78,7 @@ export class AcpSessionStore {
   }
 
   /**
-   * Load a previously persisted session by Estela session ID.
+   * Load a previously persisted session by AVA session ID.
    * Used by ACP's `session/load` capability.
    */
   async load(estelaSessionId: string): Promise<SessionState | null> {
@@ -167,9 +167,9 @@ export class AcpSessionStore {
   }
 
   /**
-   * Get the Estela session ID for an ACP session
+   * Get the AVA session ID for an ACP session
    */
-  getEstelaId(acpSessionId: string): string | null {
+  getAVAId(acpSessionId: string): string | null {
     return this.mappings.get(acpSessionId)?.estelaSessionId ?? null
   }
 

--- a/packages/core/src/acp/terminal.ts
+++ b/packages/core/src/acp/terminal.ts
@@ -22,7 +22,7 @@ import { AcpError, AcpErrorCode } from './types.js'
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
 
 /** Terminal name prefix */
-const TERMINAL_PREFIX = 'Estela'
+const TERMINAL_PREFIX = 'AVA'
 
 // ============================================================================
 // ACP Terminal Bridge

--- a/packages/core/src/acp/types.ts
+++ b/packages/core/src/acp/types.ts
@@ -2,7 +2,7 @@
  * ACP (Agent Client Protocol) Types
  *
  * Type definitions for the ACP integration layer.
- * These types bridge between the ACP protocol and Estela's internal systems.
+ * These types bridge between the ACP protocol and AVA's internal systems.
  */
 
 // ============================================================================
@@ -13,7 +13,7 @@
 export interface AcpSessionInfo {
   /** Session ID (ACP protocol) */
   sessionId: string
-  /** Mapped Estela session ID (from SessionManager) */
+  /** Mapped AVA session ID (from SessionManager) */
   estelaSessionId: string
   /** Working directory for this session */
   workingDirectory: string

--- a/packages/core/src/config/credentials.ts
+++ b/packages/core/src/config/credentials.ts
@@ -29,7 +29,7 @@ import type { CredentialKey, CredentialProvider, CredentialProviderInfo } from '
 // Constants
 // ============================================================================
 
-/** Key prefix for all Estela credentials */
+/** Key prefix for all AVA credentials */
 const KEY_PREFIX = 'estela'
 
 /** API key suffix */

--- a/packages/core/src/git/auto-commit.ts
+++ b/packages/core/src/git/auto-commit.ts
@@ -125,9 +125,9 @@ export async function autoCommitIfEnabled(
 }
 
 /**
- * Undo the last auto-commit made by Estela.
+ * Undo the last auto-commit made by AVA.
  *
- * Finds the most recent commit with the Estela prefix and reverts it.
+ * Finds the most recent commit with the AVA prefix and reverts it.
  * Only reverts commits that match the configured message prefix.
  *
  * @param cwd - Working directory (project root)
@@ -141,10 +141,10 @@ export async function undoLastAutoCommit(cwd: string): Promise<GitResult> {
   const config = getGitConfig()
   const history = await getHistory({ limit: 20 }, cwd)
 
-  // Find the most recent Estela auto-commit
+  // Find the most recent AVA auto-commit
   const estelaCommit = history.find((c) => c.message.startsWith(config.messagePrefix))
   if (!estelaCommit) {
-    return { success: false, output: '', error: 'No Estela auto-commit found to undo' }
+    return { success: false, output: '', error: 'No AVA auto-commit found to undo' }
   }
 
   // Revert the commit (creates a new revert commit)

--- a/packages/core/src/git/types.ts
+++ b/packages/core/src/git/types.ts
@@ -13,7 +13,7 @@ export interface GitConfig {
   enabled: boolean
   /** Automatically commit before modifications */
   autoCommit: boolean
-  /** Prefix for Estela-created branches */
+  /** Prefix for AVA-created branches */
   branchPrefix: string
   /** Default commit message prefix */
   messagePrefix: string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * @ava/core
- * Core business logic for Estela - LLM client, tools, types
+ * Core business logic for AVA - LLM client, tools, types
  */
 
 export type {

--- a/packages/core/src/llm/providers/openai.ts
+++ b/packages/core/src/llm/providers/openai.ts
@@ -98,7 +98,7 @@ class OpenAIClient implements LLMClient {
 
       const oauthBody = {
         model: config.model,
-        instructions: systemInstructions || 'You are Estela, a coding assistant.',
+        instructions: systemInstructions || 'You are AVA, a coding assistant.',
         input: messages
           .filter((m) => m.role !== 'system')
           .map((m) => ({

--- a/packages/core/src/llm/providers/openrouter.ts
+++ b/packages/core/src/llm/providers/openrouter.ts
@@ -66,7 +66,7 @@ class OpenRouterClient implements LLMClient {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${auth.token}`,
           'HTTP-Referer': 'https://estela.app',
-          'X-Title': 'Estela',
+          'X-Title': 'AVA',
         },
         body: JSON.stringify(body),
         signal,

--- a/packages/core/src/mcp/bridge.ts
+++ b/packages/core/src/mcp/bridge.ts
@@ -1,6 +1,6 @@
 /**
  * MCP Tool Bridge
- * Converts MCP tools to Estela tool format and registers them
+ * Converts MCP tools to AVA tool format and registers them
  */
 
 import { ToolErrorType } from '../tools/errors.js'
@@ -14,7 +14,7 @@ import type { DiscoveredMCPTool, MCPToolContent } from './types.js'
 // ============================================================================
 
 /**
- * Convert MCP tool to Estela tool format
+ * Convert MCP tool to AVA tool format
  */
 export function createToolFromMCP(mcpTool: DiscoveredMCPTool): Tool {
   const definition: ToolDefinition = {
@@ -48,7 +48,7 @@ export function createToolFromMCP(mcpTool: DiscoveredMCPTool): Tool {
         // Execute MCP tool
         const result = await mcpTool.execute(params)
 
-        // Convert MCP result to Estela format
+        // Convert MCP result to AVA format
         const output = formatMCPContent(result.content)
 
         return {

--- a/packages/core/src/mcp/discovery.ts
+++ b/packages/core/src/mcp/discovery.ts
@@ -46,7 +46,7 @@ export function getMCPConfigPaths(): string[] {
   const home = process.env.HOME ?? process.env.USERPROFILE ?? ''
 
   return [
-    // Estela config
+    // AVA config
     `${home}/.estela/mcp.json`,
 
     // Claude Code config (for compatibility)

--- a/packages/core/src/session/file-storage.ts
+++ b/packages/core/src/session/file-storage.ts
@@ -305,7 +305,7 @@ export function createFileSessionStorage(baseDir?: string): FileSessionStorage {
 }
 
 /**
- * Get the default Estela base directory
+ * Get the default AVA base directory
  */
 function getDefaultBaseDir(): string {
   const home = process.env.HOME ?? process.env.USERPROFILE ?? '.'

--- a/packages/core/src/slash-commands/commands/index.ts
+++ b/packages/core/src/slash-commands/commands/index.ts
@@ -1,7 +1,7 @@
 /**
  * Built-in Slash Commands
  *
- * Core commands that ship with Estela
+ * Core commands that ship with AVA
  */
 
 import { getFocusChainManager } from '../../focus-chain/index.js'

--- a/packages/core/src/tools/webfetch.ts
+++ b/packages/core/src/tools/webfetch.ts
@@ -27,8 +27,7 @@ interface WebFetchParams {
 const DEFAULT_MAX_CHARS = 50000
 
 /** User agent for requests */
-const USER_AGENT =
-  'Mozilla/5.0 (compatible; Estela/1.0; +https://github.com/estela) Estela WebFetch'
+const USER_AGENT = 'Mozilla/5.0 (compatible; AVA/1.0; +https://github.com/estela) AVA WebFetch'
 
 /** Request timeout in milliseconds */
 const REQUEST_TIMEOUT = 30000

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ava/platform-node",
   "version": "0.1.0",
-  "description": "Node.js platform implementations for Estela CLI",
+  "description": "Node.js platform implementations for AVA CLI",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/platform-node/src/pty.ts
+++ b/packages/platform-node/src/pty.ts
@@ -224,7 +224,7 @@ export class NodePTY implements IPTY {
         ...(process.env as Record<string, string>),
         ...options?.env,
         TERM: 'xterm-256color',
-        ESTELA_TERMINAL: '1', // Mark as Estela terminal (like OpenCode's OPENCODE_TERMINAL)
+        ESTELA_TERMINAL: '1', // Mark as AVA terminal (like OpenCode's OPENCODE_TERMINAL)
       },
     })
 

--- a/packages/platform-tauri/package.json
+++ b/packages/platform-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ava/platform-tauri",
   "version": "0.1.0",
-  "description": "Tauri platform implementations for Estela",
+  "description": "Tauri platform implementations for AVA",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,35 +13,67 @@
     "sql:allow-close",
     {
       "identifier": "fs:allow-read-text-file",
-      "allow": [{ "path": "$APPDATA/**" }, { "path": "$HOME/.estela/**" }]
+      "allow": [
+        { "path": "$APPDATA/**" },
+        { "path": "$HOME/.ava/**" },
+        { "path": "$HOME/.estela/**" }
+      ]
     },
     {
       "identifier": "fs:allow-read-file",
-      "allow": [{ "path": "$APPDATA/**" }, { "path": "$HOME/.estela/**" }]
+      "allow": [
+        { "path": "$APPDATA/**" },
+        { "path": "$HOME/.ava/**" },
+        { "path": "$HOME/.estela/**" }
+      ]
     },
     {
       "identifier": "fs:allow-read-dir",
-      "allow": [{ "path": "$APPDATA/**" }, { "path": "$HOME/.estela/**" }]
+      "allow": [
+        { "path": "$APPDATA/**" },
+        { "path": "$HOME/.ava/**" },
+        { "path": "$HOME/.estela/**" }
+      ]
     },
     {
       "identifier": "fs:allow-stat",
-      "allow": [{ "path": "$APPDATA/**" }, { "path": "$HOME/.estela/**" }]
+      "allow": [
+        { "path": "$APPDATA/**" },
+        { "path": "$HOME/.ava/**" },
+        { "path": "$HOME/.estela/**" }
+      ]
     },
     {
       "identifier": "fs:allow-write-text-file",
-      "allow": [{ "path": "$APPDATA/**" }, { "path": "$HOME/.estela/**" }]
+      "allow": [
+        { "path": "$APPDATA/**" },
+        { "path": "$HOME/.ava/**" },
+        { "path": "$HOME/.estela/**" }
+      ]
     },
     {
       "identifier": "fs:allow-remove",
-      "allow": [{ "path": "$APPDATA/**" }, { "path": "$HOME/.estela/**" }]
+      "allow": [
+        { "path": "$APPDATA/**" },
+        { "path": "$HOME/.ava/**" },
+        { "path": "$HOME/.estela/**" }
+      ]
     },
     {
       "identifier": "fs:allow-exists",
-      "allow": [{ "path": "$APPDATA/**" }, { "path": "$HOME/.estela/**" }]
+      "allow": [
+        { "path": "$APPDATA/**" },
+        { "path": "$HOME/.ava/**" },
+        { "path": "$HOME/.estela/**" }
+      ]
     },
     {
       "identifier": "fs:allow-mkdir",
-      "allow": [{ "path": "$APPDATA/**" }, { "path": "$HOME/.estela/**" }]
+      "allow": [
+        { "path": "$APPDATA/**" },
+        { "path": "$HOME/.ava/**" },
+        { "path": "$HOME/.estela/**" }
+      ]
     },
     "fs:allow-watch",
     "fs:allow-unwatch",

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -14,7 +14,7 @@ const SUCCESS_HTML: &str = r#"<!DOCTYPE html>
 <html><head><title>Authorization Complete</title>
 <style>body{font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#0a0a0f;color:#e4e4e7}
 .card{text-align:center;padding:2rem}h1{font-size:1.25rem;margin-bottom:0.5rem}p{color:#71717a;font-size:0.875rem}</style>
-</head><body><div class="card"><h1>Authorization successful</h1><p>You can close this tab and return to Estela.</p></div></body></html>"#;
+</head><body><div class="card"><h1>Authorization successful</h1><p>You can close this tab and return to AVA.</p></div></body></html>"#;
 
 const TIMEOUT_SECS: u64 = 120;
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "estela",
+  "productName": "AVA",
   "version": "0.1.0",
   "identifier": "com.xn3.estela",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Estela",
+        "title": "AVA",
         "width": 1200,
         "height": 800,
         "minWidth": 640,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ function App() {
     const cleanupShortcuts = setupShortcutListener()
     onCleanup(cleanupShortcuts)
 
-    // Guard: Estela requires the Tauri runtime
+    // Guard: AVA requires the Tauri runtime
     if (!isTauri()) {
       setNotTauri(true)
       setIsInitializing(false)
@@ -128,7 +128,7 @@ function App() {
 
       setSplashStatus('Starting logger...')
       await initLogger()
-      logInfo('App', 'Initializing Estela...')
+      logInfo('App', 'Initializing AVA...')
 
       validateEnv()
 
@@ -210,7 +210,7 @@ function App() {
               Tauri Runtime Required
             </h1>
             <p class="text-[var(--text-secondary)] mb-4 text-sm leading-relaxed">
-              Estela is a desktop app that requires the Tauri runtime. Run{' '}
+              AVA is a desktop app that requires the Tauri runtime. Run{' '}
               <code class="px-1.5 py-0.5 bg-[var(--surface-raised)] border border-[var(--border-default)] rounded text-xs font-mono">
                 npm run tauri dev
               </code>{' '}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 /**
  * Error Boundary Component
  *
- * Premium error page matching the Estela design language.
+ * Premium error page matching the AVA design language.
  * Shows a full-screen error with glass card, animations, and helpful actions.
  */
 
@@ -127,7 +127,7 @@ const ErrorFallback: Component<ErrorFallbackProps> = (props) => {
           {/* Report link */}
           <div class="stagger-child mt-6">
             <a
-              href="https://github.com/estela/issues/new"
+              href="https://github.com/g0dxn4/AVA/issues/new"
               target="_blank"
               rel="noopener noreferrer"
               class="inline-flex items-center gap-1.5 text-sm text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -62,7 +62,7 @@ export function SplashScreen(props: SplashScreenProps) {
 
         {/* App name */}
         <h1 class="text-2xl font-semibold tracking-[0.25em] uppercase text-[var(--text-primary)] mb-1.5">
-          Estela
+          AVA
         </h1>
 
         {/* Tagline */}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -248,7 +248,7 @@ export const MessageList: Component = () => {
               <Sparkles class="w-8 h-8 text-[var(--accent)]" />
             </div>
             <h2 class="text-xl font-semibold text-[var(--text-primary)] font-display">
-              Welcome to Estela
+              Welcome to AVA
             </h2>
             <p class="text-sm text-[var(--text-tertiary)] mt-2 max-w-sm text-center">
               Your AI coding assistant is ready. Start a conversation to begin.

--- a/src/components/dialogs/OnboardingDialog.tsx
+++ b/src/components/dialogs/OnboardingDialog.tsx
@@ -138,7 +138,7 @@ export const OnboardingScreen: Component<OnboardingProps> = (props) => {
 
               <div class="stagger-child">
                 <h1 class="text-3xl font-bold text-[var(--text-primary)] tracking-tight mb-3">
-                  Welcome to Estela
+                  Welcome to AVA
                 </h1>
               </div>
 
@@ -341,7 +341,7 @@ export const OnboardingScreen: Component<OnboardingProps> = (props) => {
                 <h2 class="text-2xl font-bold text-[var(--text-primary)] tracking-tight mb-1">
                   What You Can Do
                 </h2>
-                <p class="text-sm text-[var(--text-muted)]">Estela's core capabilities</p>
+                <p class="text-sm text-[var(--text-muted)]">AVA's core capabilities</p>
               </div>
 
               <div class="grid grid-cols-2 gap-3 mb-6">
@@ -379,7 +379,7 @@ export const OnboardingScreen: Component<OnboardingProps> = (props) => {
 
               <div class="stagger-child">
                 <p class="text-base text-[var(--text-secondary)] max-w-sm leading-relaxed mb-8">
-                  Estela is ready. Start a conversation to begin coding with your AI team.
+                  AVA is ready. Start a conversation to begin coding with your AI team.
                 </p>
               </div>
 
@@ -390,7 +390,7 @@ export const OnboardingScreen: Component<OnboardingProps> = (props) => {
                   class="onboarding-btn-primary inline-flex items-center gap-2 px-8 py-3 bg-[var(--accent)] text-white font-medium rounded-xl text-base"
                 >
                   <Sparkles class="w-5 h-5" />
-                  Launch Estela
+                  Launch AVA
                 </button>
               </div>
             </div>

--- a/src/components/layout/MainArea.tsx
+++ b/src/components/layout/MainArea.tsx
@@ -40,7 +40,7 @@ const WelcomeState: Component = () => (
       >
         <Sparkles class="w-8 h-8 text-white" />
       </div>
-      <h2 class="text-lg font-semibold text-[var(--text-primary)] mb-1">Welcome to Estela</h2>
+      <h2 class="text-lg font-semibold text-[var(--text-primary)] mb-1">Welcome to AVA</h2>
       <p class="text-sm text-[var(--text-secondary)] mb-4">Start a new conversation to begin</p>
       <kbd class="px-2 py-1 text-xs text-[var(--text-muted)] bg-[var(--surface-raised)] border border-[var(--border-subtle)] rounded-[var(--radius-md)]">
         Ctrl+N

--- a/src/components/settings/DeviceCodeDialog.tsx
+++ b/src/components/settings/DeviceCodeDialog.tsx
@@ -92,7 +92,7 @@ export const DeviceCodeDialog: Component<DeviceCodeDialogProps> = (props) => {
 
         {/* Instructions */}
         <p class="text-[var(--text-sm)] text-[var(--text-secondary)] mb-4">
-          Go to the URL below and enter the code to authorize Estela.
+          Go to the URL below and enter the code to authorize AVA.
         </p>
 
         {/* User Code */}

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -657,7 +657,7 @@ const GeneralSection: Component = () => {
       </div>
 
       <div class="pt-2 border-t border-[var(--border-subtle)]">
-        <span class="text-[10px] font-mono text-[var(--text-muted)]">Estela v0.1.0-alpha</span>
+        <span class="text-[10px] font-mono text-[var(--text-muted)]">AVA v0.1.0-alpha</span>
       </div>
     </div>
   )
@@ -719,7 +719,7 @@ const AboutSection: Component = () => {
   return (
     <div class="space-y-4">
       <div>
-        <h3 class="text-sm font-semibold text-[var(--text-primary)]">Estela</h3>
+        <h3 class="text-sm font-semibold text-[var(--text-primary)]">AVA</h3>
         <p class="text-xs text-[var(--text-muted)] mt-1">
           Desktop AI coding app with a virtual dev team and community plugins.
         </p>
@@ -740,7 +740,7 @@ const AboutSection: Component = () => {
       </div>
 
       <a
-        href="https://github.com/estela-ai/estela"
+        href="https://github.com/g0dxn4/AVA"
         target="_blank"
         rel="noopener noreferrer"
         class="inline-flex items-center gap-1.5 text-xs text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"

--- a/src/components/settings/tabs/ProvidersTab.test.tsx
+++ b/src/components/settings/tabs/ProvidersTab.test.tsx
@@ -6,21 +6,26 @@ vi.mock('@ava/core', () => ({
 }))
 
 function writeCredentials(payload: Record<string, unknown>) {
-  localStorage.setItem('estela_credentials', JSON.stringify(payload))
+  localStorage.setItem('ava_credentials', JSON.stringify(payload))
 }
 
 function writeCoreAuth(providerId: string, payload: Record<string, unknown>) {
-  localStorage.setItem(`estela_cred_auth-${providerId}`, JSON.stringify(payload))
+  localStorage.setItem(`ava_cred_auth-${providerId}`, JSON.stringify(payload))
 }
 
 describe('ProvidersTab helpers', () => {
   beforeEach(() => localStorage.clear())
   afterEach(() => localStorage.clear())
 
-  it('checkStoredOAuth returns true for estela_credentials oauth-token', () => {
+  it('checkStoredOAuth returns true for ava_credentials oauth-token', () => {
     writeCredentials({
       openai: { type: 'oauth-token' },
     })
+    expect(checkStoredOAuth('openai')).toBe(true)
+  })
+
+  it('checkStoredOAuth falls back to legacy estela credentials', () => {
+    localStorage.setItem('estela_credentials', JSON.stringify({ openai: { type: 'oauth-token' } }))
     expect(checkStoredOAuth('openai')).toBe(true)
   })
 
@@ -39,18 +44,23 @@ describe('ProvidersTab helpers', () => {
       openai: { type: 'oauth-token' },
       anthropic: { type: 'oauth-token' },
     })
-    localStorage.setItem('estela_cred_openai-api-key', 'sk-openai')
+    localStorage.setItem('ava_cred_openai-api-key', 'sk-openai')
+    localStorage.setItem('estela_cred_openai-api-key', 'legacy-openai')
     writeCoreAuth('openai', { type: 'oauth' })
+    localStorage.setItem('estela_cred_auth-openai', JSON.stringify({ type: 'oauth' }))
 
     clearProviderCredentials('openai')
 
-    const stored = JSON.parse(localStorage.getItem('estela_credentials') || '{}') as Record<
+    const stored = JSON.parse(localStorage.getItem('ava_credentials') || '{}') as Record<
       string,
       unknown
     >
     expect(stored.openai).toBeUndefined()
     expect(stored.anthropic).toBeDefined()
+    expect(localStorage.getItem('ava_cred_openai-api-key')).toBeNull()
+    expect(localStorage.getItem('ava_cred_auth-openai')).toBeNull()
     expect(localStorage.getItem('estela_cred_openai-api-key')).toBeNull()
     expect(localStorage.getItem('estela_cred_auth-openai')).toBeNull()
+    expect(localStorage.getItem('estela_credentials')).toBe(localStorage.getItem('ava_credentials'))
   })
 })

--- a/src/components/settings/tabs/ProvidersTab.tsx
+++ b/src/components/settings/tabs/ProvidersTab.tsx
@@ -115,7 +115,7 @@ export const ProvidersTab: Component<ProvidersTabProps> = (props) => {
       </div>
 
       <p class="text-[10px] text-[var(--text-muted)] text-center">
-        Keys stored locally · Never sent to Estela servers
+        Keys stored locally · Never sent to AVA servers
       </p>
     </div>
   )

--- a/src/components/settings/tabs/providers-tab-helpers.ts
+++ b/src/components/settings/tabs/providers-tab-helpers.ts
@@ -1,31 +1,55 @@
+const AVA_CREDENTIALS_KEY = 'ava_credentials'
+const AVA_CREDENTIAL_PREFIX = 'ava_cred_'
+const LEGACY_CREDENTIAL_PREFIX = 'estela_cred_'
+
+function readCredentialsMap(): Record<string, unknown> {
+  const raw =
+    localStorage.getItem(AVA_CREDENTIALS_KEY) || localStorage.getItem('estela_credentials')
+  if (!raw) {
+    return {}
+  }
+
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+function writeCredentialsMap(map: Record<string, unknown>): void {
+  const serialized = JSON.stringify(map)
+  localStorage.setItem(AVA_CREDENTIALS_KEY, serialized)
+  localStorage.setItem('estela_credentials', serialized)
+}
+
 export function clearProviderCredentials(providerId: string): void {
   // Clear from frontend credentials store
-  try {
-    const stored = localStorage.getItem('estela_credentials')
-    if (stored) {
-      const all = JSON.parse(stored) as Record<string, unknown>
-      delete all[providerId]
-      localStorage.setItem('estela_credentials', JSON.stringify(all))
-    }
-  } catch {
-    // Ignore
-  }
-  // Clear stale estela_cred_ prefixed keys (API key + auth)
-  localStorage.removeItem(`estela_cred_${providerId}-api-key`)
-  localStorage.removeItem(`estela_cred_auth-${providerId}`)
+  const all = readCredentialsMap()
+  delete all[providerId]
+  writeCredentialsMap(all)
+
+  // Clear both ava_cred_ and estela_cred_ prefixed keys (API key + auth)
+  localStorage.removeItem(`${AVA_CREDENTIAL_PREFIX}${providerId}-api-key`)
+  localStorage.removeItem(`${AVA_CREDENTIAL_PREFIX}auth-${providerId}`)
+  localStorage.removeItem(`${LEGACY_CREDENTIAL_PREFIX}${providerId}-api-key`)
+  localStorage.removeItem(`${LEGACY_CREDENTIAL_PREFIX}auth-${providerId}`)
 }
 
 export function checkStoredOAuth(providerId: string): boolean {
   try {
-    const stored = localStorage.getItem('estela_credentials')
-    if (stored) {
-      const all = JSON.parse(stored) as Record<string, { type?: string }>
-      if (all[providerId]?.type === 'oauth-token') return true
+    const all = readCredentialsMap() as Record<string, { type?: string }>
+    if (all[providerId]?.type === 'oauth-token') {
+      return true
     }
-    const coreAuth = localStorage.getItem(`estela_cred_auth-${providerId}`)
+
+    const coreAuth =
+      localStorage.getItem(`${AVA_CREDENTIAL_PREFIX}auth-${providerId}`) ||
+      localStorage.getItem(`${LEGACY_CREDENTIAL_PREFIX}auth-${providerId}`)
     if (coreAuth) {
       const parsed = JSON.parse(coreAuth) as { type?: string }
-      if (parsed.type === 'oauth') return true
+      if (parsed.type === 'oauth') {
+        return true
+      }
     }
   } catch {
     // Ignore parse errors

--- a/src/contexts/theme.tsx
+++ b/src/contexts/theme.tsx
@@ -1,5 +1,5 @@
 /**
- * Theme Context for Estela
+ * Theme Context for AVA
  *
  * Single dark theme - no switching needed.
  * Kept minimal for future expansion if needed.

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 /**
- * Estela Global Styles
+ * AVA Global Styles
  *
  * Single dark theme, minimal setup.
  */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,7 +71,7 @@ const LoadingFallback = () => (
       </svg>
     </div>
     <h1 class="text-xl font-semibold tracking-widest uppercase text-[var(--text-primary)] mb-8">
-      Estela
+      AVA
     </h1>
     <div class="flex gap-1.5">
       <span

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,5 +1,5 @@
 /**
- * Motion utilities for Estela
+ * Motion utilities for AVA
  *
  * Reusable spring presets and reduced-motion hook.
  * Uses solid-motionone (Motion One for SolidJS).

--- a/src/pages/DesignSystemPreview.tsx
+++ b/src/pages/DesignSystemPreview.tsx
@@ -41,7 +41,7 @@ export const DesignSystemPreview: Component = () => {
             <div class="w-12 h-12 rounded-xl bg-[var(--accent)] flex items-center justify-center">
               <Sparkles class="w-6 h-6 text-white" />
             </div>
-            <h1 class="text-3xl font-bold">Estela Design System</h1>
+            <h1 class="text-3xl font-bold">AVA Design System</h1>
           </div>
           <p class="text-[var(--text-secondary)]">Component library preview - Dark theme</p>
         </div>

--- a/src/preview.html
+++ b/src/preview.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Estela Settings Preview</title>
+  <title>AVA Settings Preview</title>
   <link rel="stylesheet" href="./styles/tokens.css">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -220,7 +220,7 @@
   </style>
 </head>
 <body>
-  <h1>Estela Design System Preview</h1>
+  <h1>AVA Design System Preview</h1>
 
   <div class="preview-grid">
     <!-- Providers Preview -->
@@ -386,7 +386,7 @@
 
       <div class="info-banner">
         <div class="info-icon">ℹ️</div>
-        <div class="info-text">MCP servers extend Estela's capabilities with additional tools, data sources, and integrations.</div>
+        <div class="info-text">MCP servers extend AVA's capabilities with additional tools, data sources, and integrations.</div>
       </div>
     </div>
   </div>

--- a/src/services/auth/oauth.test.ts
+++ b/src/services/auth/oauth.test.ts
@@ -99,18 +99,19 @@ describe('storeOAuthCredentials', () => {
 
   it('stores credentials in localStorage', () => {
     storeOAuthCredentials('anthropic', { accessToken: 'tok-abc' })
-    const raw = localStorage.getItem('estela_credentials')
+    const raw = localStorage.getItem('ava_credentials')
     expect(raw).not.toBeNull()
     const parsed = JSON.parse(raw!)
     expect(parsed.anthropic.provider).toBe('anthropic')
     expect(parsed.anthropic.type).toBe('oauth-token')
     expect(parsed.anthropic.value).toBe('tok-abc')
+    expect(localStorage.getItem('estela_credentials')).toBe(raw)
   })
 
   it('stores multiple providers without overwriting', () => {
     storeOAuthCredentials('anthropic', { accessToken: 'tok-a' })
     storeOAuthCredentials('openai', { accessToken: 'tok-o' })
-    const parsed = JSON.parse(localStorage.getItem('estela_credentials')!)
+    const parsed = JSON.parse(localStorage.getItem('ava_credentials')!)
     expect(parsed.anthropic.value).toBe('tok-a')
     expect(parsed.openai.value).toBe('tok-o')
   })

--- a/src/services/auth/oauth.ts
+++ b/src/services/auth/oauth.ts
@@ -19,6 +19,7 @@ import type { Credentials, LLMProvider } from '../../types/llm'
 import { logDebug, logError, logInfo, logWarn } from '../logger'
 
 const LOG_SRC = 'oauth'
+const AVA_CREDENTIALS_KEY = 'ava_credentials'
 
 // ============================================================================
 // Types
@@ -566,7 +567,8 @@ export function storeOAuthCredentials(provider: LLMProvider, tokens: OAuthTokens
     expiresAt: tokens.expiresAt,
     refreshToken: tokens.refreshToken,
   }
-  const stored = localStorage.getItem('estela_credentials')
+  const stored =
+    localStorage.getItem(AVA_CREDENTIALS_KEY) || localStorage.getItem(STORAGE_KEYS.CREDENTIALS)
   let all: Record<string, Credentials> = {}
   try {
     if (stored) all = JSON.parse(stored)
@@ -574,7 +576,9 @@ export function storeOAuthCredentials(provider: LLMProvider, tokens: OAuthTokens
     all = {}
   }
   all[provider] = credentials
-  localStorage.setItem('estela_credentials', JSON.stringify(all))
+  const serialized = JSON.stringify(all)
+  localStorage.setItem(AVA_CREDENTIALS_KEY, serialized)
+  localStorage.setItem(STORAGE_KEYS.CREDENTIALS, serialized)
 
   // Anthropic: OAuth mints a real API key — store as plain API key
   if (provider === 'anthropic') {

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -166,7 +166,7 @@ export async function initLogger(): Promise<void> {
     initialized = true
 
     // Write startup marker
-    pushEntry('info', 'Logger', '--- Estela session started ---')
+    pushEntry('info', 'Logger', '--- AVA session started ---')
     pushEntry('info', 'Logger', `Log file: $APPDATA/${LOG_FILE}`)
   } catch (err) {
     console.warn('[Logger] Failed to initialize file logger:', err)

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,5 +1,5 @@
 /**
- * Estela Design System 2026
+ * AVA Design System 2026
  *
  * Premium, minimal, dark-first design tokens.
  * Architecture: Primitives → Semantic Tokens → Component Tokens

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-// Core types for Estela
+// Core types for AVA
 
 // Message error for retry functionality
 export interface MessageError {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import solidPlugin from 'vite-plugin-solid'
 import { defineConfig } from 'vitest/config'
 
@@ -25,5 +26,14 @@ export default defineConfig({
   },
   resolve: {
     conditions: ['development', 'browser'],
+    alias: {
+      '@ava/core': fileURLToPath(new URL('./packages/core/src/index.ts', import.meta.url)),
+      '@ava/platform-tauri': fileURLToPath(
+        new URL('./packages/platform-tauri/src/index.ts', import.meta.url)
+      ),
+      '@ava/platform-node': fileURLToPath(
+        new URL('./packages/platform-node/src/index.ts', import.meta.url)
+      ),
+    },
   },
 })


### PR DESCRIPTION
## Summary
- complete AVA branding rename sweep across app text, docs, package descriptions, and Tauri product metadata
- keep compatibility for existing installs by preserving legacy storage behavior while adding AVA credential key support
- add Vitest workspace aliases for  packages and update OAuth/provider tests for migration-safe behavior

## Verification
- npx tsc --noEmit
- pnpm run lint
- pnpm run format:check
- pnpm vitest run src/services/auth/oauth.test.ts src/components/settings/tabs/ProvidersTab.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added backward compatibility for legacy credential storage with automatic migration
  - Expanded filesystem access capabilities for additional configuration directories

* **Documentation**
  - Updated all documentation, guides, and technical resources with current product information

* **Style**
  - Updated product naming, branding, and visual identity throughout the application and UI
  - Updated repository URLs and configuration references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->