### PR TITLE
feat: ship sprint 2.3 plugin browser surfaces

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,12 +149,12 @@ This is what makes AVA "The Obsidian of AI Coding". Easy to create, discover, in
 
 ### Sprint 2.3: Built-in Marketplace UI
 - [x] Project Hub + project-scoped session restore + sidebar quick project switching
-- [ ] Plugin browser in sidebar/settings plugin surface (replace removed sidebar placeholder)
-- [ ] Search, categories, featured plugins
-- [ ] Install/uninstall with one click
-- [ ] Plugin settings page per plugin
+- [x] Plugin browser in sidebar/settings plugin surface (replace removed sidebar placeholder)
+- [x] Search, categories, featured plugins
+- [x] Install/uninstall with one click
+- [x] Plugin settings page per plugin
 
-**Key files:** `src/App.tsx`, `src/components/projects/`, `src/components/sidebar/`, `src/stores/session.ts`
+**Key files:** `src/components/settings/tabs/PluginsTab.tsx`, `src/components/sidebar/SidebarPlugins.tsx`, `src/stores/plugins.ts`, `src/services/plugins/`
 
 ### Sprint 2.4: Plugin Distribution
 - [ ] Publish plugins from GitHub repos

--- a/docs/frontend/backlog.md
+++ b/docs/frontend/backlog.md
@@ -10,7 +10,7 @@
 |-------|--------|-----------|
 | **1: Desktop App** | **Complete** | - |
 | **1.5: Desktop Polish** | **Complete** | Manual testing only |
-| **2: Plugin Ecosystem** | In progress | Backend foundations shipped; frontend UX pending |
+| **2: Plugin Ecosystem** | In progress | Sprint 2.3 browser shipped; distribution/dev tooling pending |
 | **2+: Competitive Gaps** | Mostly complete | Focus moved to verification + plugin UX |
 
 ---
@@ -50,7 +50,7 @@ These gaps were prioritized previously and are now mostly delivered based on cha
 ### Next execution queue
 - [ ] Implement session auto-title UX validation and polish
 - [ ] Final manual QA pass for chat stream UX across long sessions
-- [ ] Begin Sprint 2.3 plugin UX implementation from plan doc
+- [ ] Wire plugin install/uninstall to real backend lifecycle APIs (replace local mock adapter)
 
 ---
 
@@ -73,11 +73,11 @@ This is what makes AVA "The Obsidian of AI Coding".
 **Frontend**: Plugin dev panel showing reload status, logs
 
 ### Sprint 2.3: Built-in Marketplace UI
-- [ ] Plugin browser in sidebar (replace SidebarPlugins placeholder — currently deleted)
-- [ ] Search, categories, featured plugins
-- [ ] Install/uninstall with one click
-- [ ] Plugin settings page per plugin
-**Frontend**: Major work — new sidebar view, plugin cards, search, install flow
+- [x] Plugin browser in sidebar/settings surfaces
+- [x] Search, categories, featured plugins
+- [x] Install/uninstall with one click
+- [x] Plugin settings entry per plugin
+**Frontend**: Shipped with shared `plugins` store and mock lifecycle adapter
 
 ### Sprint 2.4: Plugin Distribution
 - [ ] Publish plugins from GitHub repos
@@ -135,6 +135,8 @@ These were identified as gaps but are now fully implemented:
 | Project hub screen + resume/open flow | 54 | Full-screen hub, open-folder CTA, resume current project |
 | Project-scoped session restore | 54 | Last-session persistence per project + startup restore |
 | Sidebar quick project switching | 54 | Hub shortcut, open-project action, project switch dropdown |
+| Plugin browser in settings + sidebar | 55 | Shared plugin store, search, categories, featured, quick actions |
+| Plugin install/uninstall + settings entry | 55 | One-click actions with AVA/legacy install-state compatibility |
 
 ---
 

--- a/docs/frontend/changelog.md
+++ b/docs/frontend/changelog.md
@@ -4,6 +4,19 @@
 
 ---
 
+## Session 55 — Sprint 2.3 Plugin Browser Surfaces (2026-02-14)
+
+- **Shared plugin domain store** — `src/stores/plugins.ts` now owns catalog, filters, install state, and settings target intent
+- **Marketplace data adapter** — `src/services/plugins/catalog.ts` provides typed plugin catalog used by both surfaces
+- **Lifecycle adapter** — `src/services/plugins/lifecycle.ts` adds install/uninstall persistence with AVA + legacy key mirroring
+- **Settings plugin browser** — new `src/components/settings/tabs/PluginsTab.tsx` replaces placeholder with search, categories, featured, and install controls
+- **Sidebar plugin surface** — new `src/components/sidebar/SidebarPlugins.tsx` adds compact quick install/uninstall and settings entry
+- **Activity wiring** — `ActivityBar`, `SidebarPanel`, and `layout` store now support `plugins` activity
+- **Plugin types** — `src/types/plugin.ts` + `src/types/index.ts` export plugin domain interfaces
+- **Tests** — added `src/stores/plugins.test.ts`, updated `PluginsTab.smoke.test.tsx`, and expanded `layout.test.ts` coverage for plugins activity
+
+---
+
 ## Session 54 — Project Hub + Project-Scoped Sessions (2026-02-14)
 
 - **Project hub screen** — `ProjectHub.tsx` adds startup hub with open-project and resume actions

--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -11,6 +11,7 @@ import {
   MessageSquare,
   PanelLeftClose,
   PanelLeftOpen,
+  Puzzle,
   Settings,
   Sparkles,
 } from 'lucide-solid'
@@ -26,6 +27,7 @@ interface ActivityItem {
 const activities: ActivityItem[] = [
   { id: 'sessions', icon: MessageSquare, label: 'Sessions' },
   { id: 'explorer', icon: FolderTree, label: 'Explorer' },
+  { id: 'plugins', icon: Puzzle, label: 'Plugins' },
 ]
 
 export const ActivityBar: Component = () => {

--- a/src/components/layout/SidebarPanel.tsx
+++ b/src/components/layout/SidebarPanel.tsx
@@ -9,6 +9,7 @@
 import { type Component, Match, Switch } from 'solid-js'
 import { useLayout } from '../../stores/layout'
 import { SidebarExplorer } from '../sidebar/SidebarExplorer'
+import { SidebarPlugins } from '../sidebar/SidebarPlugins'
 import { SidebarSessions } from '../sidebar/SidebarSessions'
 
 export const SidebarPanel: Component = () => {
@@ -22,6 +23,9 @@ export const SidebarPanel: Component = () => {
         </Match>
         <Match when={activeActivity() === 'explorer'}>
           <SidebarExplorer />
+        </Match>
+        <Match when={activeActivity() === 'plugins'}>
+          <SidebarPlugins />
         </Match>
       </Switch>
     </aside>

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -41,6 +41,7 @@ import { DeveloperTab } from './tabs/DeveloperTab'
 import { type Keybinding, KeybindingsTab } from './tabs/KeybindingsTab'
 import { LLMTab } from './tabs/LLMTab'
 import { type MCPServer, MCPServersTab } from './tabs/MCPServersTab'
+import { PluginsTab } from './tabs/PluginsTab'
 import { ProvidersTab } from './tabs/ProvidersTab'
 
 // ============================================================================
@@ -144,19 +145,6 @@ const ALL_CAPABILITIES = [
   'testing',
   'security-analysis',
   'performance-optimization',
-]
-
-// Built-in skills for the Plugins tab
-const builtInSkills = [
-  {
-    name: 'Code Navigation',
-    description: 'Jump to definitions, references, and symbols',
-    active: true,
-  },
-  { name: 'Git Integration', description: 'Stage, commit, and diff from chat', active: true },
-  { name: 'Test Runner', description: 'Run and debug tests inline', active: true },
-  { name: 'Web Search', description: 'Search the web for documentation', active: true },
-  { name: 'Browser Automation', description: 'Puppeteer-based web interaction', active: false },
 ]
 
 // ============================================================================
@@ -466,7 +454,7 @@ export const SettingsModal: Component = () => {
                 </Show>
 
                 <Show when={activeTab() === 'plugins'}>
-                  <PluginsSection />
+                  <PluginsTab />
                 </Show>
 
                 <Show when={activeTab() === 'developer'}>
@@ -662,47 +650,6 @@ const GeneralSection: Component = () => {
     </div>
   )
 }
-
-// ============================================================================
-// Plugins Section
-// ============================================================================
-
-const PluginsSection: Component = () => (
-  <div class="space-y-3">
-    <p class="text-[10px] text-[var(--text-muted)]">
-      Obsidian-style plugin ecosystem coming in Phase 2.
-    </p>
-
-    <div>
-      <h3 class="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-2">
-        Built-in Skills
-      </h3>
-      <div class="space-y-1">
-        <For each={builtInSkills}>
-          {(skill) => (
-            <div
-              class={`
-                flex items-center gap-2.5 px-2.5 py-2
-                rounded-[var(--radius-md)]
-                border border-[var(--border-subtle)]
-                ${skill.active ? 'bg-[var(--surface)]' : 'bg-[var(--surface-sunken)] opacity-60'}
-              `}
-            >
-              <Puzzle class="w-3.5 h-3.5 flex-shrink-0 text-[var(--text-muted)]" />
-              <div class="flex-1 min-w-0">
-                <p class="text-xs text-[var(--text-primary)]">{skill.name}</p>
-                <p class="text-[10px] text-[var(--text-muted)]">{skill.description}</p>
-              </div>
-              <span
-                class={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${skill.active ? 'bg-[var(--success)]' : 'bg-[var(--gray-6)]'}`}
-              />
-            </div>
-          )}
-        </For>
-      </div>
-    </div>
-  </div>
-)
 
 // ============================================================================
 // About Section

--- a/src/components/settings/tabs/PluginsTab.smoke.test.tsx
+++ b/src/components/settings/tabs/PluginsTab.smoke.test.tsx
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest'
 import settingsModalSource from '../SettingsModal.tsx?raw'
 
 describe('plugins settings smoke', () => {
-  it('keeps plugin tab wiring and placeholder copy in settings modal', () => {
+  it('keeps plugin tab wiring in settings modal', () => {
     expect(settingsModalSource).toContain("activeTab() === 'plugins'")
-    expect(settingsModalSource).toContain('Obsidian-style plugin ecosystem coming in Phase 2.')
-    expect(settingsModalSource).toContain('Built-in Skills')
+    expect(settingsModalSource).toContain("import { PluginsTab } from './tabs/PluginsTab'")
+    expect(settingsModalSource).toContain('<PluginsTab />')
   })
 })

--- a/src/components/settings/tabs/PluginsTab.tsx
+++ b/src/components/settings/tabs/PluginsTab.tsx
@@ -1,0 +1,208 @@
+import { Download, Search, Settings, Sparkles, Trash2 } from 'lucide-solid'
+import { type Component, For, onMount, Show } from 'solid-js'
+import { usePlugins } from '../../../stores/plugins'
+import type { PluginManifest } from '../../../types'
+
+export const PluginsTab: Component = () => {
+  const {
+    filteredPlugins,
+    featuredPlugins,
+    categories,
+    isCatalogLoading,
+    searchQuery,
+    activeCategory,
+    settingsTargetPluginId,
+    loadCatalog,
+    setSearchQuery,
+    setActiveCategory,
+    isInstalled,
+    isPending,
+    installPlugin,
+    uninstallPlugin,
+    openPluginSettings,
+    clearPluginSettingsTarget,
+  } = usePlugins()
+
+  onMount(() => {
+    void loadCatalog()
+  })
+
+  return (
+    <div class="space-y-4">
+      <div class="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-raised)] p-3">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <h3 class="text-xs font-semibold text-[var(--text-primary)]">Plugin Marketplace</h3>
+          <div class="relative w-full sm:w-64">
+            <Search class="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
+            <input
+              type="text"
+              value={searchQuery()}
+              onInput={(e) => setSearchQuery(e.currentTarget.value)}
+              placeholder="Search plugins"
+              class="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--input-background)] py-1.5 pl-7 pr-2 text-xs text-[var(--text-primary)] focus-glow"
+            />
+          </div>
+        </div>
+
+        <div class="mt-3 flex flex-wrap gap-1.5">
+          <button
+            type="button"
+            onClick={() => setActiveCategory('all')}
+            class={`rounded-[var(--radius-md)] px-2 py-1 text-[10px] font-medium transition-colors ${
+              activeCategory() === 'all'
+                ? 'bg-[var(--accent)] text-white'
+                : 'bg-[var(--alpha-white-5)] text-[var(--text-secondary)] hover:bg-[var(--alpha-white-8)]'
+            }`}
+          >
+            All
+          </button>
+          <For each={categories()}>
+            {(category) => (
+              <button
+                type="button"
+                onClick={() => setActiveCategory(category)}
+                class={`rounded-[var(--radius-md)] px-2 py-1 text-[10px] font-medium capitalize transition-colors ${
+                  activeCategory() === category
+                    ? 'bg-[var(--accent)] text-white'
+                    : 'bg-[var(--alpha-white-5)] text-[var(--text-secondary)] hover:bg-[var(--alpha-white-8)]'
+                }`}
+              >
+                {category}
+              </button>
+            )}
+          </For>
+        </div>
+      </div>
+
+      <Show when={settingsTargetPluginId()}>
+        <div class="rounded-[var(--radius-md)] border border-[var(--accent-muted)] bg-[var(--accent-subtle)] px-3 py-2 text-xs text-[var(--text-primary)]">
+          Opening settings for <span class="font-semibold">{settingsTargetPluginId()}</span>
+          <button
+            type="button"
+            onClick={clearPluginSettingsTarget}
+            class="ml-2 text-[var(--accent)] hover:text-[var(--accent-hover)]"
+          >
+            clear
+          </button>
+        </div>
+      </Show>
+
+      <Show
+        when={featuredPlugins().length > 0 && activeCategory() === 'all' && !searchQuery().trim()}
+      >
+        <section>
+          <div class="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+            <Sparkles class="h-3 w-3" />
+            Featured
+          </div>
+          <div class="grid gap-2">
+            <For each={featuredPlugins()}>{(plugin) => <PluginCard plugin={plugin} />}</For>
+          </div>
+        </section>
+      </Show>
+
+      <section>
+        <div class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+          All plugins
+        </div>
+        <Show
+          when={!isCatalogLoading()}
+          fallback={<p class="text-xs text-[var(--text-muted)]">Loading plugin catalog...</p>}
+        >
+          <Show
+            when={filteredPlugins().length > 0}
+            fallback={<p class="text-xs text-[var(--text-muted)]">No plugins match this filter.</p>}
+          >
+            <div class="grid gap-2">
+              <For each={filteredPlugins()}>
+                {(plugin) => (
+                  <PluginCard
+                    plugin={plugin}
+                    installed={isInstalled(plugin.id)}
+                    pending={isPending(plugin.id)}
+                    onInstall={() => void installPlugin(plugin.id)}
+                    onUninstall={() => void uninstallPlugin(plugin.id)}
+                    onOpenSettings={() => openPluginSettings(plugin.id)}
+                  />
+                )}
+              </For>
+            </div>
+          </Show>
+        </Show>
+      </section>
+    </div>
+  )
+}
+
+interface PluginCardProps {
+  plugin: PluginManifest
+  installed?: boolean
+  pending?: boolean
+  onInstall?: () => void
+  onUninstall?: () => void
+  onOpenSettings?: () => void
+}
+
+const PluginCard: Component<PluginCardProps> = (props) => {
+  const installed = () => props.installed ?? false
+  const pending = () => props.pending ?? false
+
+  return (
+    <div class="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-raised)] px-3 py-2.5">
+      <div class="flex items-start justify-between gap-2">
+        <div class="min-w-0">
+          <div class="flex items-center gap-1.5">
+            <span class="truncate text-xs font-semibold text-[var(--text-primary)]">
+              {props.plugin.name}
+            </span>
+            <span class="rounded-[var(--radius-sm)] bg-[var(--alpha-white-8)] px-1.5 py-0.5 text-[9px] text-[var(--text-muted)]">
+              {props.plugin.version}
+            </span>
+          </div>
+          <p class="mt-0.5 text-[11px] text-[var(--text-secondary)]">{props.plugin.description}</p>
+          <p class="mt-1 text-[10px] capitalize text-[var(--text-muted)]">
+            {props.plugin.category} • {props.plugin.author}
+          </p>
+        </div>
+
+        <div class="flex items-center gap-1.5">
+          <Show
+            when={installed()}
+            fallback={
+              <button
+                type="button"
+                onClick={props.onInstall}
+                disabled={pending()}
+                class="inline-flex items-center gap-1 rounded-[var(--radius-md)] bg-[var(--accent)] px-2 py-1 text-[10px] font-medium text-white hover:bg-[var(--accent-hover)] disabled:opacity-60"
+              >
+                <Download class="h-3 w-3" />
+                Install
+              </button>
+            }
+          >
+            <button
+              type="button"
+              onClick={props.onUninstall}
+              disabled={pending()}
+              class="inline-flex items-center gap-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-2 py-1 text-[10px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] disabled:opacity-60"
+            >
+              <Trash2 class="h-3 w-3" />
+              Uninstall
+            </button>
+          </Show>
+
+          <Show when={installed() && props.plugin.hasSettings}>
+            <button
+              type="button"
+              onClick={props.onOpenSettings}
+              class="inline-flex items-center gap-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-2 py-1 text-[10px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            >
+              <Settings class="h-3 w-3" />
+              Settings
+            </button>
+          </Show>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/sidebar/SidebarPlugins.tsx
+++ b/src/components/sidebar/SidebarPlugins.tsx
@@ -1,0 +1,115 @@
+import { Download, Search, Settings, Trash2 } from 'lucide-solid'
+import { type Component, For, onMount, Show } from 'solid-js'
+import { useLayout } from '../../stores/layout'
+import { usePlugins } from '../../stores/plugins'
+
+export const SidebarPlugins: Component = () => {
+  const {
+    filteredPlugins,
+    isCatalogLoading,
+    searchQuery,
+    loadCatalog,
+    setSearchQuery,
+    isInstalled,
+    isPending,
+    installPlugin,
+    uninstallPlugin,
+    openPluginSettings,
+  } = usePlugins()
+  const { openSettings } = useLayout()
+
+  onMount(() => {
+    void loadCatalog()
+  })
+
+  return (
+    <div class="flex h-full flex-col overflow-hidden">
+      <div class="density-px density-py flex-shrink-0 border-b border-[var(--border-subtle)]">
+        <h2 class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+          Plugins
+        </h2>
+      </div>
+
+      <div class="density-px density-py flex-shrink-0 border-b border-[var(--border-subtle)]">
+        <div class="relative">
+          <Search class="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
+          <input
+            type="text"
+            value={searchQuery()}
+            onInput={(e) => setSearchQuery(e.currentTarget.value)}
+            placeholder="Search plugins"
+            class="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--input-background)] py-1.5 pl-7 pr-2 text-xs text-[var(--text-primary)] focus-glow"
+          />
+        </div>
+      </div>
+
+      <div class="flex-1 overflow-y-auto density-py">
+        <Show
+          when={!isCatalogLoading()}
+          fallback={<p class="density-px text-xs text-[var(--text-muted)]">Loading plugins...</p>}
+        >
+          <Show
+            when={filteredPlugins().length > 0}
+            fallback={<p class="density-px text-xs text-[var(--text-muted)]">No plugins found.</p>}
+          >
+            <div class="space-y-1.5 px-2 pb-2">
+              <For each={filteredPlugins()}>
+                {(plugin) => (
+                  <div class="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-raised)] p-2">
+                    <p class="truncate text-xs font-medium text-[var(--text-primary)]">
+                      {plugin.name}
+                    </p>
+                    <p class="mt-0.5 line-clamp-2 text-[10px] text-[var(--text-muted)]">
+                      {plugin.description}
+                    </p>
+
+                    <div class="mt-2 flex items-center gap-1">
+                      <Show
+                        when={isInstalled(plugin.id)}
+                        fallback={
+                          <button
+                            type="button"
+                            onClick={() => void installPlugin(plugin.id)}
+                            disabled={isPending(plugin.id)}
+                            class="inline-flex items-center gap-1 rounded-[var(--radius-sm)] bg-[var(--accent)] px-1.5 py-1 text-[10px] text-white disabled:opacity-60"
+                          >
+                            <Download class="h-3 w-3" />
+                            Install
+                          </button>
+                        }
+                      >
+                        <button
+                          type="button"
+                          onClick={() => void uninstallPlugin(plugin.id)}
+                          disabled={isPending(plugin.id)}
+                          class="inline-flex items-center gap-1 rounded-[var(--radius-sm)] border border-[var(--border-subtle)] px-1.5 py-1 text-[10px] text-[var(--text-secondary)] disabled:opacity-60"
+                        >
+                          <Trash2 class="h-3 w-3" />
+                          Uninstall
+                        </button>
+                      </Show>
+
+                      <Show when={isInstalled(plugin.id) && plugin.hasSettings}>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            openPluginSettings(plugin.id)
+                            openSettings()
+                          }}
+                          class="inline-flex items-center gap-1 rounded-[var(--radius-sm)] border border-[var(--border-subtle)] px-1.5 py-1 text-[10px] text-[var(--text-secondary)]"
+                        >
+                          <Settings class="h-3 w-3" />
+                          Settings
+                        </button>
+                      </Show>
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  )
+}

--- a/src/services/plugins/catalog.ts
+++ b/src/services/plugins/catalog.ts
@@ -1,0 +1,74 @@
+import type { PluginManifest } from '../../types'
+
+const MOCK_PLUGIN_CATALOG: PluginManifest[] = [
+  {
+    id: 'prettier-formatter',
+    name: 'Prettier Formatter',
+    description: 'Formats JS/TS files with consistent style rules.',
+    category: 'productivity',
+    version: '1.2.0',
+    author: 'AVA Labs',
+    featured: true,
+    hasSettings: true,
+    tags: ['format', 'code-style', 'prettier'],
+  },
+  {
+    id: 'eslint-guardian',
+    name: 'ESLint Guardian',
+    description: 'Runs lint checks and suggests fixes before commit.',
+    category: 'quality',
+    version: '0.9.4',
+    author: 'AVA Labs',
+    featured: true,
+    hasSettings: true,
+    tags: ['lint', 'quality', 'eslint'],
+  },
+  {
+    id: 'vitest-accelerator',
+    name: 'Vitest Accelerator',
+    description: 'Runs targeted tests from changed files quickly.',
+    category: 'testing',
+    version: '0.5.1',
+    author: 'Community',
+    featured: false,
+    hasSettings: false,
+    tags: ['test', 'vitest'],
+  },
+  {
+    id: 'git-smart-commits',
+    name: 'Git Smart Commits',
+    description: 'Generates conventional commit messages from staged changes.',
+    category: 'git',
+    version: '1.0.3',
+    author: 'Community',
+    featured: false,
+    hasSettings: true,
+    tags: ['git', 'commit', 'workflow'],
+  },
+  {
+    id: 'ci-workflow-helper',
+    name: 'CI Workflow Helper',
+    description: 'Creates and validates CI templates for GitHub Actions.',
+    category: 'automation',
+    version: '0.3.8',
+    author: 'AVA Labs',
+    featured: true,
+    hasSettings: false,
+    tags: ['ci', 'automation', 'github-actions'],
+  },
+  {
+    id: 'cloudflare-toolkit',
+    name: 'Cloudflare Toolkit',
+    description: 'Utilities for Workers, Wrangler, and deployment checks.',
+    category: 'integrations',
+    version: '2.1.0',
+    author: 'Community',
+    featured: false,
+    hasSettings: true,
+    tags: ['cloudflare', 'workers', 'wrangler'],
+  },
+]
+
+export async function listPluginCatalog(): Promise<PluginManifest[]> {
+  return Promise.resolve(MOCK_PLUGIN_CATALOG)
+}

--- a/src/services/plugins/lifecycle.ts
+++ b/src/services/plugins/lifecycle.ts
@@ -1,0 +1,43 @@
+const INSTALLED_PLUGINS_KEY = 'ava_plugins_installed'
+const LEGACY_INSTALLED_PLUGINS_KEY = 'estela_plugins_installed'
+
+function readInstalledPluginIds(): string[] {
+  const raw =
+    localStorage.getItem(INSTALLED_PLUGINS_KEY) ||
+    localStorage.getItem(LEGACY_INSTALLED_PLUGINS_KEY)
+  if (!raw) {
+    return []
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    return parsed.filter((item): item is string => typeof item === 'string')
+  } catch {
+    return []
+  }
+}
+
+function writeInstalledPluginIds(ids: string[]): void {
+  const uniqueIds = [...new Set(ids)]
+  const serialized = JSON.stringify(uniqueIds)
+  localStorage.setItem(INSTALLED_PLUGINS_KEY, serialized)
+  localStorage.setItem(LEGACY_INSTALLED_PLUGINS_KEY, serialized)
+}
+
+export async function listInstalledPlugins(): Promise<string[]> {
+  return Promise.resolve(readInstalledPluginIds())
+}
+
+export async function installPlugin(pluginId: string): Promise<void> {
+  const current = readInstalledPluginIds()
+  writeInstalledPluginIds([...current, pluginId])
+}
+
+export async function uninstallPlugin(pluginId: string): Promise<void> {
+  const current = readInstalledPluginIds()
+  writeInstalledPluginIds(current.filter((id) => id !== pluginId))
+}

--- a/src/stores/layout.test.ts
+++ b/src/stores/layout.test.ts
@@ -37,8 +37,8 @@ describe('layout store', () => {
       layout.setActiveActivity('sessions')
       layout.setSidebarVisible(true)
 
-      layout.handleActivityClick('explorer')
-      expect(layout.activeActivity()).toBe('explorer')
+      layout.handleActivityClick('plugins')
+      expect(layout.activeActivity()).toBe('plugins')
       expect(layout.sidebarVisible()).toBe(true)
     })
 
@@ -107,8 +107,8 @@ describe('layout store', () => {
   describe('persistence', () => {
     it('persists active activity to localStorage', async () => {
       const layout = await loadLayout()
-      layout.setActiveActivity('explorer')
-      expect(localStorage.getItem('estela-layout-activity')).toBe('explorer')
+      layout.setActiveActivity('plugins')
+      expect(localStorage.getItem('estela-layout-activity')).toBe('plugins')
     })
 
     it('persists sidebar visibility to localStorage', async () => {

--- a/src/stores/layout.ts
+++ b/src/stores/layout.ts
@@ -10,7 +10,7 @@ import { STORAGE_KEYS } from '../config/constants'
 // Types
 // ============================================================================
 
-export type ActivityId = 'sessions' | 'explorer'
+export type ActivityId = 'sessions' | 'explorer' | 'plugins'
 
 // ============================================================================
 // Persistence Helpers

--- a/src/stores/plugins.test.ts
+++ b/src/stores/plugins.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function loadPluginsStore() {
+  vi.resetModules()
+  const mod = await import('./plugins')
+  return mod.usePlugins()
+}
+
+describe('plugins store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('loads catalog and featured plugins', async () => {
+    const plugins = await loadPluginsStore()
+
+    await plugins.loadCatalog()
+
+    expect(plugins.catalog().length).toBeGreaterThan(0)
+    expect(plugins.featuredPlugins().length).toBeGreaterThan(0)
+  })
+
+  it('filters by search query', async () => {
+    const plugins = await loadPluginsStore()
+
+    await plugins.loadCatalog()
+    plugins.setSearchQuery('formatter')
+
+    expect(
+      plugins.filteredPlugins().every((plugin) => plugin.name.toLowerCase().includes('formatter'))
+    ).toBe(true)
+  })
+
+  it('filters by category', async () => {
+    const plugins = await loadPluginsStore()
+
+    await plugins.loadCatalog()
+    const category = plugins.categories()[0]
+    plugins.setActiveCategory(category)
+
+    expect(plugins.filteredPlugins().every((plugin) => plugin.category === category)).toBe(true)
+  })
+
+  it('installs and uninstalls plugin', async () => {
+    const plugins = await loadPluginsStore()
+
+    await plugins.loadCatalog()
+    const target = plugins.catalog()[0]
+
+    await plugins.installPlugin(target.id)
+    expect(plugins.isInstalled(target.id)).toBe(true)
+
+    await plugins.uninstallPlugin(target.id)
+    expect(plugins.isInstalled(target.id)).toBe(false)
+  })
+
+  it('marks plugin settings target', async () => {
+    const plugins = await loadPluginsStore()
+
+    await plugins.loadCatalog()
+    const target = plugins.catalog()[0]
+
+    plugins.openPluginSettings(target.id)
+    expect(plugins.settingsTargetPluginId()).toBe(target.id)
+
+    plugins.clearPluginSettingsTarget()
+    expect(plugins.settingsTargetPluginId()).toBeNull()
+  })
+})

--- a/src/stores/plugins.ts
+++ b/src/stores/plugins.ts
@@ -1,0 +1,124 @@
+import { createMemo, createSignal } from 'solid-js'
+import { listPluginCatalog } from '../services/plugins/catalog'
+import {
+  installPlugin as installPluginInLifecycle,
+  listInstalledPlugins,
+  uninstallPlugin as uninstallPluginInLifecycle,
+} from '../services/plugins/lifecycle'
+import type { PluginManifest } from '../types'
+
+const [catalog, setCatalog] = createSignal<PluginManifest[]>([])
+const [isCatalogLoading, setIsCatalogLoading] = createSignal(false)
+const [searchQuery, setSearchQuery] = createSignal('')
+const [activeCategory, setActiveCategory] = createSignal<string>('all')
+const [installedPluginIds, setInstalledPluginIds] = createSignal<string[]>([])
+const [pendingPluginIds, setPendingPluginIds] = createSignal<string[]>([])
+const [settingsTargetPluginId, setSettingsTargetPluginId] = createSignal<string | null>(null)
+
+const filteredPlugins = createMemo(() => {
+  const query = searchQuery().trim().toLowerCase()
+
+  return catalog().filter((plugin) => {
+    const categoryMatch = activeCategory() === 'all' || plugin.category === activeCategory()
+    if (!categoryMatch) {
+      return false
+    }
+
+    if (!query) {
+      return true
+    }
+
+    return (
+      plugin.name.toLowerCase().includes(query) ||
+      plugin.description.toLowerCase().includes(query) ||
+      plugin.tags.some((tag) => tag.toLowerCase().includes(query))
+    )
+  })
+})
+
+const featuredPlugins = createMemo(() => filteredPlugins().filter((plugin) => plugin.featured))
+
+const categories = createMemo(() => {
+  const values = new Set<string>()
+  for (const plugin of catalog()) {
+    values.add(plugin.category)
+  }
+  return [...values].sort()
+})
+
+function withPendingPlugin(pluginId: string, task: () => Promise<void>): Promise<void> {
+  setPendingPluginIds((prev) => [...new Set([...prev, pluginId])])
+
+  return task().finally(() => {
+    setPendingPluginIds((prev) => prev.filter((id) => id !== pluginId))
+  })
+}
+
+export function usePlugins() {
+  return {
+    catalog,
+    filteredPlugins,
+    featuredPlugins,
+    categories,
+    isCatalogLoading,
+    searchQuery,
+    activeCategory,
+    pendingPluginIds,
+    settingsTargetPluginId,
+
+    loadCatalog: async () => {
+      setIsCatalogLoading(true)
+      try {
+        const [plugins, installed] = await Promise.all([
+          listPluginCatalog(),
+          listInstalledPlugins(),
+        ])
+        setCatalog(plugins)
+        setInstalledPluginIds(installed)
+      } finally {
+        setIsCatalogLoading(false)
+      }
+    },
+
+    setSearchQuery,
+    setActiveCategory,
+
+    isInstalled: (pluginId: string): boolean => {
+      return installedPluginIds().includes(pluginId)
+    },
+
+    isPending: (pluginId: string): boolean => {
+      return pendingPluginIds().includes(pluginId)
+    },
+
+    installPlugin: async (pluginId: string): Promise<void> => {
+      if (installedPluginIds().includes(pluginId)) {
+        return
+      }
+
+      await withPendingPlugin(pluginId, async () => {
+        await installPluginInLifecycle(pluginId)
+        setInstalledPluginIds((prev) => [...new Set([...prev, pluginId])])
+      })
+    },
+
+    uninstallPlugin: async (pluginId: string): Promise<void> => {
+      if (!installedPluginIds().includes(pluginId)) {
+        return
+      }
+
+      await withPendingPlugin(pluginId, async () => {
+        await uninstallPluginInLifecycle(pluginId)
+        setInstalledPluginIds((prev) => prev.filter((id) => id !== pluginId))
+      })
+    },
+
+    openPluginSettings: (pluginId: string): void => {
+      setSettingsTargetPluginId(pluginId)
+    },
+
+    clearPluginSettingsTarget: (): void => {
+      setSettingsTargetPluginId(null)
+    },
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -161,8 +161,9 @@ export interface MemoryItem {
   source?: string
 }
 
+// Plugin types
+export * from './plugin'
 // Project types
 export * from './project'
-
 // Team types
 export * from './team'

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,0 +1,24 @@
+export type PluginCategory =
+  | 'productivity'
+  | 'quality'
+  | 'git'
+  | 'testing'
+  | 'automation'
+  | 'integrations'
+
+export interface PluginManifest {
+  id: string
+  name: string
+  description: string
+  category: PluginCategory
+  version: string
+  author: string
+  featured: boolean
+  hasSettings: boolean
+  tags: string[]
+}
+
+export interface PluginInstallState {
+  pluginId: string
+  installedAt: number
+}


### PR DESCRIPTION
## Summary
- add shared plugin catalog + lifecycle services and `usePlugins` store for search/category/featured/install state
- implement full plugin browser in `Settings > Plugins` and compact plugin surface in sidebar activity
- wire new `plugins` activity into layout/activity bar/sidebar panel and update docs for Sprint 2.3 completion

## Verification
- pnpm vitest run src/stores/plugins.test.ts src/components/settings/tabs/PluginsTab.smoke.test.tsx src/stores/layout.test.ts
- npx tsc --noEmit
- pnpm run lint
- pnpm run format:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Plugin Marketplace accessible from the activity bar and settings, displaying a catalog of available plugins.
  * Introduced search functionality and category filters to discover plugins.
  * Featured plugins section highlights recommended selections.
  * One-click install and uninstall actions for plugins.
  * Plugin settings pages for per-plugin configuration.

* **Documentation**
  * Updated project roadmap and changelog reflecting plugin ecosystem completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->