### PR TITLE
fix: position top underscores of ASCII ART logo correctly.

### DIFF
--- a/crates/ava-tui/src/widgets/welcome.rs
+++ b/crates/ava-tui/src/widgets/welcome.rs
@@ -10,7 +10,7 @@ use ratatui::Frame;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const ASCII_ART: &[&str] = &[
-    "   _   __   __  _   ",
+    "   _  __   __  _   ",
     "  /_\\ \\ \\ / / /_\\  ",
     " / _ \\ \\ V / / _ \\ ",
     "/_/ \\_\\ \\_/ /_/ \\_\\",


### PR DESCRIPTION
## Summary

The splash ASCII ART was displayed incorrectly,
namely:

       _   __   __  _
       /_\ \ \ / / /_\
      / _ \ \ V / / _ \
     /_/ \_\ \_/ /_/ \_\
     
note the top underscore of the first A.

## Checklist

- [N/A] Tests/lint run locally (Only changed a string literal)
- [N/A] Docs updated for behavior/status changes; no behavior was changed.
